### PR TITLE
카카오 로그인 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -83,6 +83,7 @@ android {
 dependencies {
 
     implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.core.splashscreen)
     implementation(libs.androidx.datastore)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.navigation.runtime.ktx)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -78,6 +78,10 @@ dependencies {
     implementation(platform(libs.compose.bom))
     implementation(libs.bundles.compose)
 
+    implementation(platform(libs.okhttp.bom))
+    implementation(libs.bundles.okhttp)
+    implementation(libs.bundles.retrofit)
+
     implementation(libs.kotlinx.serialization.json)
 
     implementation(libs.kakao.v2.user)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,5 +1,6 @@
 import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import java.util.Properties
 
 plugins {
     alias(libs.plugins.android.application)
@@ -13,6 +14,10 @@ plugins {
 android {
     namespace = "com.coinkiri.coinkiri"
     compileSdk = 34
+
+    val properties = Properties().apply {
+        load(rootProject.file("local.properties").inputStream())
+    }
 
     defaultConfig {
         applicationId = "com.coinkiri.coinkiri"
@@ -37,7 +42,14 @@ android {
     }
 
     buildTypes {
+        debug {
+            val devUrl = properties["coinkiriDevUrl"] as? String ?: ""
+            buildConfigField("String", "BASE_URL", devUrl)
+        }
         release {
+            val prodUrl = properties["coinkiriProdUrl"] as? String ?: ""
+            buildConfigField("String", "BASE_URL", prodUrl)
+
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,7 +38,7 @@ android {
         )
 
         manifestPlaceholders["KAKAO_NATIVE_APP_KEY"] =
-            gradleLocalProperties(rootDir, providers).getProperty("kakaoNativeAppKey")
+            gradleLocalProperties(rootDir, providers).getProperty("kakaoNative.AppKey")
     }
 
     buildTypes {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,6 +70,7 @@ android {
 dependencies {
 
     implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.datastore)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.navigation.runtime.ktx)
     implementation(libs.androidx.activity.compose)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -84,6 +84,9 @@ dependencies {
 
     implementation(libs.kotlinx.serialization.json)
 
+    implementation(libs.timber)
+    implementation(libs.process.phoenix)
+
     implementation(libs.kakao.v2.user)
 
     implementation(libs.hilt.android)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -23,6 +24,15 @@ android {
         vectorDrawables {
             useSupportLibrary = true
         }
+
+        buildConfigField(
+            "String",
+            "KAKAO_NATIVE_APP_KEY",
+            gradleLocalProperties(rootDir, providers).getProperty("kakaoNativeAppKey"),
+        )
+
+        manifestPlaceholders["KAKAO_NATIVE_APP_KEY"] =
+            gradleLocalProperties(rootDir, providers).getProperty("kakaoNativeAppKey")
     }
 
     buildTypes {
@@ -45,6 +55,7 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
     composeOptions {
         kotlinCompilerExtensionVersion = "1.5.1"
@@ -64,6 +75,8 @@ dependencies {
     implementation(libs.androidx.activity.compose)
     implementation(platform(libs.compose.bom))
     implementation(libs.bundles.compose)
+
+    implementation(libs.kakao.v2.user)
 
     implementation(libs.hilt.android)
     implementation(libs.hilt.navigation.compose)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.compose.complier)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
@@ -76,6 +77,8 @@ dependencies {
     implementation(libs.androidx.activity.compose)
     implementation(platform(libs.compose.bom))
     implementation(libs.bundles.compose)
+
+    implementation(libs.kotlinx.serialization.json)
 
     implementation(libs.kakao.v2.user)
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:name=".CoinkiriApplication"
         android:allowBackup="true"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
@@ -15,16 +14,28 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Coinkiri"
-        tools:targetApi="31"
-        >
+        tools:targetApi="31">
         <activity
             android:name=".ui.main.MainActivity"
             android:exported="true"
-            android:theme="@style/Theme.Coinkiri"
-            >
+            android:theme="@style/Theme.Coinkiri">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+        <activity
+            android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="oauth"
+                    android:scheme="kakao${KAKAO_NATIVE_APP_KEY}" />
             </intent-filter>
         </activity>
     </application>

--- a/app/src/main/java/com/coinkiri/coinkiri/CoinkiriApplication.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/CoinkiriApplication.kt
@@ -1,7 +1,18 @@
 package com.coinkiri.coinkiri
 
 import android.app.Application
+import com.kakao.sdk.common.KakaoSdk
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
-class CoinkiriApplication: Application()
+class CoinkiriApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+
+        initKakaoSdk()
+    }
+
+    private fun initKakaoSdk() {
+        KakaoSdk.init(this, BuildConfig.KAKAO_NATIVE_APP_KEY)
+    }
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/CoinkiriApplication.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/CoinkiriApplication.kt
@@ -3,13 +3,19 @@ package com.coinkiri.coinkiri
 import android.app.Application
 import com.kakao.sdk.common.KakaoSdk
 import dagger.hilt.android.HiltAndroidApp
+import timber.log.Timber
 
 @HiltAndroidApp
 class CoinkiriApplication : Application() {
     override fun onCreate() {
         super.onCreate()
 
+        initTimber()
         initKakaoSdk()
+    }
+
+    private fun initTimber() {
+        if (BuildConfig.DEBUG) Timber.plant(Timber.DebugTree())
     }
 
     private fun initKakaoSdk() {

--- a/app/src/main/java/com/coinkiri/coinkiri/core/datastore/TokenDataStore.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/core/datastore/TokenDataStore.kt
@@ -1,0 +1,13 @@
+package com.coinkiri.coinkiri.core.datastore
+
+import kotlinx.coroutines.flow.Flow
+
+interface TokenDataStore {
+    val accessTokenFlow: Flow<String>
+    val refreshTokenFlow: Flow<String>
+
+    suspend fun setAccessToken(value: String)
+    suspend fun setRefreshToken(value: String)
+
+    suspend fun clearInfo()
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/core/datastore/TokenDataStoreImpl.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/core/datastore/TokenDataStoreImpl.kt
@@ -1,0 +1,49 @@
+package com.coinkiri.coinkiri.core.datastore
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Named
+
+class TokenDataStoreImpl @Inject constructor(
+    @Named("token") private val dataStore: DataStore<Preferences>,
+) : TokenDataStore {
+
+    private val accessTokenKey = stringPreferencesKey(ACCESS_TOKEN)
+    private val refreshTokenKey = stringPreferencesKey(REFRESH_TOKEN)
+
+    override val accessTokenFlow: Flow<String> = dataStore.data.map { preferences ->
+        preferences[accessTokenKey] ?: ""
+    }
+
+    override val refreshTokenFlow: Flow<String> = dataStore.data.map { preferences ->
+        preferences[refreshTokenKey] ?: ""
+    }
+
+    override suspend fun setAccessToken(value: String) {
+        dataStore.edit { preferences ->
+            preferences[accessTokenKey] = value
+        }
+    }
+
+    override suspend fun setRefreshToken(value: String) {
+        dataStore.edit { preferences ->
+            preferences[refreshTokenKey] = value
+        }
+    }
+
+    override suspend fun clearInfo() {
+        dataStore.edit { preferences ->
+            preferences.clear()
+        }
+    }
+
+    companion object {
+        private const val ACCESS_TOKEN = "ACCESS_TOKEN"
+        private const val REFRESH_TOKEN = "REFRESH_TOKEN"
+    }
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/core/datastore/di/DataStoreModule.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/core/datastore/di/DataStoreModule.kt
@@ -1,0 +1,28 @@
+package com.coinkiri.coinkiri.core.datastore.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+import com.coinkiri.coinkiri.core.datastore.TokenDataStore
+import com.coinkiri.coinkiri.core.datastore.TokenDataStoreImpl
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DataStoreModule {
+    private const val TOKEN_DATASTORE_NAME = "TOKEN_PREFERENCES"
+    private val Context.tokenDataStore by preferencesDataStore(TOKEN_DATASTORE_NAME)
+
+    @Provides
+    @Singleton
+    @Named("token")
+    fun provideTokenDataStore(@ApplicationContext context: Context): DataStore<Preferences> =
+        context.tokenDataStore
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/core/datastore/di/TokenDataStoreModule.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/core/datastore/di/TokenDataStoreModule.kt
@@ -1,0 +1,22 @@
+package com.coinkiri.coinkiri.core.datastore.di
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import com.coinkiri.coinkiri.core.datastore.TokenDataStore
+import com.coinkiri.coinkiri.core.datastore.TokenDataStoreImpl
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object TokenDataStoreModule {
+
+    @Provides
+    @Singleton
+    fun provideTokenDataStoreImpl(@Named("token") dataStore: DataStore<Preferences>): TokenDataStore =
+        TokenDataStoreImpl(dataStore)
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/core/network/BaseResponse.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/core/network/BaseResponse.kt
@@ -1,0 +1,14 @@
+package com.coinkiri.coinkiri.core.network
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class BaseResponse<T>(
+    @SerialName("code")
+    val code: Int,
+    @SerialName("message")
+    val message: String,
+    @SerialName("data")
+    val data: T,
+)

--- a/app/src/main/java/com/coinkiri/coinkiri/core/network/NetworkModule.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/core/network/NetworkModule.kt
@@ -1,6 +1,7 @@
 package com.coinkiri.coinkiri.core.network
 
 import com.coinkiri.coinkiri.BuildConfig
+import com.coinkiri.coinkiri.BuildConfig.BASE_URL
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -8,10 +9,12 @@ import dagger.hilt.components.SingletonComponent
 import kotlinx.serialization.json.Json
 import okhttp3.Interceptor
 import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import org.json.JSONArray
 import org.json.JSONObject
 import retrofit2.Converter
+import retrofit2.Retrofit
 import retrofit2.converter.kotlinx.serialization.asConverterFactory
 import timber.log.Timber
 import javax.inject.Singleton
@@ -53,5 +56,54 @@ object NetworkModule {
         level =
             if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BODY else HttpLoggingInterceptor.Level.NONE
     }
+
+    @Provides
+    @Singleton
+    @JWT
+    fun provideOauthInterceptor(authInterceptor: OauthInterceptor): Interceptor = authInterceptor
+
+    @Provides
+    @Singleton
+    @JWT
+    fun provideJWTOkHttpClient(
+        loggingInterceptor: Interceptor,
+        @JWT oauthInterceptor: Interceptor
+    ): OkHttpClient = OkHttpClient.Builder()
+        .addInterceptor(loggingInterceptor)
+        .addInterceptor(oauthInterceptor)
+        .build()
+
+    @Provides
+    @Singleton
+    @REISSUE
+    fun provideOkHttpClient(
+        loggingInterceptor: Interceptor,
+    ): OkHttpClient = OkHttpClient.Builder()
+        .addInterceptor(loggingInterceptor)
+        .build()
+
+    @Provides
+    @Singleton
+    @JWT
+    fun provideJWTRetrofit(
+        @JWT client: OkHttpClient,
+        factory: Converter.Factory,
+    ): Retrofit = Retrofit.Builder()
+        .baseUrl(BASE_URL)
+        .client(client)
+        .addConverterFactory(factory)
+        .build()
+
+    @Provides
+    @Singleton
+    @REISSUE
+    fun provideReissueRetrofit(
+        @REISSUE client: OkHttpClient,
+        factory: Converter.Factory,
+    ): Retrofit = Retrofit.Builder()
+        .baseUrl(BASE_URL)
+        .client(client)
+        .addConverterFactory(factory)
+        .build()
 
 }

--- a/app/src/main/java/com/coinkiri/coinkiri/core/network/NetworkModule.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/core/network/NetworkModule.kt
@@ -1,0 +1,57 @@
+package com.coinkiri.coinkiri.core.network
+
+import com.coinkiri.coinkiri.BuildConfig
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.serialization.json.Json
+import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.logging.HttpLoggingInterceptor
+import org.json.JSONArray
+import org.json.JSONObject
+import retrofit2.Converter
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
+import timber.log.Timber
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object NetworkModule {
+    private const val APPLICATION_JSON = "application/json"
+    private const val OKHTTP = "okhttp"
+    private const val UNIT_TAB = 4
+
+    @Provides
+    @Singleton
+    fun provideJson(): Json = Json {
+        ignoreUnknownKeys = true
+        prettyPrint = true
+    }
+
+    @Provides
+    @Singleton
+    fun provideJsonConverter(json: Json): Converter.Factory =
+        json.asConverterFactory(APPLICATION_JSON.toMediaType())
+
+    @Provides
+    @Singleton
+    fun provideHttpLoggingInterceptor(): Interceptor = HttpLoggingInterceptor { message ->
+        when {
+            message.isJsonObject() ->
+                Timber.tag(OKHTTP).d(JSONObject(message).toString(UNIT_TAB))
+
+            message.isJsonArray() ->
+                Timber.tag(OKHTTP).d(JSONArray(message).toString(UNIT_TAB))
+
+            else -> {
+                Timber.tag(OKHTTP).d("CONNECTION INFO -> $message")
+            }
+        }
+    }.apply {
+        level =
+            if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BODY else HttpLoggingInterceptor.Level.NONE
+    }
+
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/core/network/OauthInterceptor.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/core/network/OauthInterceptor.kt
@@ -1,0 +1,110 @@
+package com.coinkiri.coinkiri.core.network
+
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import com.coinkiri.coinkiri.core.datastore.TokenDataStore
+import com.coinkiri.coinkiri.domain.reissuetoken.repository.ReissueTokenRepository
+import com.jakewharton.processphoenix.ProcessPhoenix
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import okhttp3.Interceptor
+import okhttp3.Request
+import okhttp3.Response
+import timber.log.Timber
+import javax.inject.Inject
+
+class OauthInterceptor @Inject constructor(
+    private val reissueTokenRepository: ReissueTokenRepository,
+    private val dataStore: TokenDataStore,
+    @ApplicationContext private val context: Context
+) : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        return runBlocking {
+            val originalRequest = chain.request()
+            val authRequest = addAuthorization(originalRequest)
+
+            val response = chain.proceed(authRequest)
+            if (response.code == TOKEN_EXPIRED) {
+                handleTokenExpiration(chain, authRequest, response)
+            } else {
+                response
+            }
+        }
+    }
+
+    private suspend fun addAuthorization(request: Request): Request {
+        val accessToken = dataStore.accessTokenFlow.firstOrNull().orEmpty()
+        return if (accessToken.isNotBlank()) {
+            request.newBuilder().addAuthorizationHeader(accessToken).build()
+        } else {
+            request
+        }
+    }
+
+    private fun Request.Builder.addAuthorizationHeader(token: String) =
+        this.addHeader(AUTHORIZATION, "$BEARER $token")
+
+    private suspend fun handleTokenExpiration(
+        chain: Interceptor.Chain,
+        authRequest: Request,
+        response: Response
+    ): Response {
+        response.close()
+        return if (tryReissueToken()) {
+            val newAccessToken = dataStore.accessTokenFlow.firstOrNull().orEmpty()
+            val newRequest = authRequest.newBuilder()
+                .addAuthorizationHeader(newAccessToken)
+                .build()
+            chain.proceed(newRequest)
+        } else {
+            clearUserInfoAndRestart()
+            chain.proceed(authRequest.newBuilder().build())
+        }
+    }
+
+    private suspend fun tryReissueToken(): Boolean {
+        return try {
+            val refreshToken = dataStore.refreshTokenFlow.firstOrNull().orEmpty()
+            val result = reissueTokenRepository.postReissueToken("$BEARER $refreshToken")
+            result.onSuccess { data ->
+                Timber.d("Successfully reissued token: ${data.refreshToken}")
+                updateTokens(data.accessToken, data.refreshToken)
+            }.onFailure { error ->
+                Timber.e("Failed to reissue token: $error")
+            }
+            result.isSuccess
+        } catch (t: Throwable) {
+            Timber.e(t, "Exception occurred while reissuing token")
+            false
+        }
+    }
+
+    private suspend fun updateTokens(newAccessToken: String, newRefreshToken: String) {
+        Timber.e("NEW ACCESS TOKEN : $newAccessToken")
+        Timber.e("NEW REFRESH TOKEN : $newRefreshToken")
+        withContext(Dispatchers.IO) {
+            dataStore.setAccessToken(newAccessToken)
+            dataStore.setRefreshToken(newRefreshToken)
+        }
+    }
+
+    private fun clearUserInfoAndRestart() {
+        runBlocking {
+            dataStore.clearInfo()
+        }
+        Handler(Looper.getMainLooper()).post {
+            ProcessPhoenix.triggerRebirth(context)
+        }
+    }
+
+    companion object {
+        private const val TOKEN_EXPIRED = 401
+        private const val BEARER = "Bearer"
+        private const val AUTHORIZATION = "Authorization"
+    }
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/core/network/Qualifier.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/core/network/Qualifier.kt
@@ -1,0 +1,11 @@
+package com.coinkiri.coinkiri.core.network
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class REISSUE
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class JWT

--- a/app/src/main/java/com/coinkiri/coinkiri/core/network/StringExtension.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/core/network/StringExtension.kt
@@ -1,0 +1,5 @@
+package com.coinkiri.coinkiri.core.network
+
+fun String?.isJsonObject(): Boolean = this?.startsWith("{") == true && this.endsWith("}")
+
+fun String?.isJsonArray(): Boolean = this?.startsWith("[") == true && this.endsWith("]")

--- a/app/src/main/java/com/coinkiri/coinkiri/data/login/datasource/LoginDataSource.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/data/login/datasource/LoginDataSource.kt
@@ -1,0 +1,13 @@
+package com.coinkiri.coinkiri.data.login.datasource
+
+import com.coinkiri.coinkiri.core.network.BaseResponse
+import com.coinkiri.coinkiri.data.login.dto.request.LoginRequestDto
+import com.coinkiri.coinkiri.data.login.dto.response.LoginResponseDto
+
+interface LoginDataSource {
+
+    suspend fun postLogin(
+        accessToken: String,
+        platform: LoginRequestDto,
+    ): BaseResponse<LoginResponseDto>
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/data/login/datasourceimpl/LoginDataSourceImpl.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/data/login/datasourceimpl/LoginDataSourceImpl.kt
@@ -1,0 +1,19 @@
+package com.coinkiri.coinkiri.data.login.datasourceimpl
+
+import com.coinkiri.coinkiri.core.network.BaseResponse
+import com.coinkiri.coinkiri.data.login.datasource.LoginDataSource
+import com.coinkiri.coinkiri.data.login.dto.request.LoginRequestDto
+import com.coinkiri.coinkiri.data.login.dto.response.LoginResponseDto
+import com.coinkiri.coinkiri.data.login.service.LoginService
+import javax.inject.Inject
+
+class LoginDataSourceImpl @Inject constructor(
+    private val loginService: LoginService
+) : LoginDataSource {
+
+    override suspend fun postLogin(
+        accessToken: String,
+        platform: LoginRequestDto
+    ): BaseResponse<LoginResponseDto> =
+        loginService.postLogin(accessToken, platform)
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/data/login/di/DataSourceModule.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/data/login/di/DataSourceModule.kt
@@ -1,0 +1,18 @@
+package com.coinkiri.coinkiri.data.login.di
+
+import com.coinkiri.coinkiri.data.login.datasource.LoginDataSource
+import com.coinkiri.coinkiri.data.login.datasourceimpl.LoginDataSourceImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class DataSourceModule {
+
+    @Binds
+    @Singleton
+    abstract fun provideLoginDataSource(loginDataSourceImpl: LoginDataSourceImpl): LoginDataSource
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/data/login/di/RepositoryModule.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/data/login/di/RepositoryModule.kt
@@ -1,0 +1,18 @@
+package com.coinkiri.coinkiri.data.login.di
+
+import com.coinkiri.coinkiri.data.login.repositoryimpl.LoginRepositoryImpl
+import com.coinkiri.coinkiri.domain.login.repository.LoginRepository
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class RepositoryModule {
+
+    @Binds
+    @Singleton
+    abstract fun provideLoginRepository(loginRepositoryImpl: LoginRepositoryImpl): LoginRepository
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/data/login/di/ServiceModule.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/data/login/di/ServiceModule.kt
@@ -1,0 +1,20 @@
+package com.coinkiri.coinkiri.data.login.di
+
+import com.coinkiri.coinkiri.core.network.REISSUE
+import com.coinkiri.coinkiri.data.login.service.LoginService
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object ServiceModule {
+
+    @Provides
+    @Singleton
+    fun provideLoginService(@REISSUE retrofit: Retrofit): LoginService =
+        retrofit.create(LoginService::class.java)
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/data/login/dto/request/LoginRequestDto.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/data/login/dto/request/LoginRequestDto.kt
@@ -1,0 +1,14 @@
+package com.coinkiri.coinkiri.data.login.dto.request
+
+import com.coinkiri.coinkiri.domain.login.entity.request.LoginRequestEntity
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class LoginRequestDto(
+    @SerialName("platform")
+    val platform: String
+)
+
+fun LoginRequestEntity.toLoginRequestDto(): LoginRequestDto =
+    LoginRequestDto(platform)

--- a/app/src/main/java/com/coinkiri/coinkiri/data/login/dto/response/LoginResponseDto.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/data/login/dto/response/LoginResponseDto.kt
@@ -1,0 +1,19 @@
+package com.coinkiri.coinkiri.data.login.dto.response
+
+import com.coinkiri.coinkiri.domain.login.entity.reponse.LoginResponseEntity
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class LoginResponseDto(
+    @SerialName("accessToken")
+    val accessToken: String,
+    @SerialName("refreshToken")
+    val refreshToken: String
+) {
+    fun toLoginEntity() =
+        LoginResponseEntity(
+            accessToken = accessToken,
+            refreshToken = refreshToken,
+        )
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/data/login/repositoryimpl/LoginRepositoryImpl.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/data/login/repositoryimpl/LoginRepositoryImpl.kt
@@ -1,0 +1,23 @@
+package com.coinkiri.coinkiri.data.login.repositoryimpl
+
+import com.coinkiri.coinkiri.data.login.datasource.LoginDataSource
+import com.coinkiri.coinkiri.data.login.dto.request.toLoginRequestDto
+import com.coinkiri.coinkiri.domain.login.entity.reponse.LoginResponseEntity
+import com.coinkiri.coinkiri.domain.login.entity.request.LoginRequestEntity
+import com.coinkiri.coinkiri.domain.login.repository.LoginRepository
+import javax.inject.Inject
+
+class LoginRepositoryImpl @Inject constructor(
+    private val loginDataSource: LoginDataSource,
+) : LoginRepository {
+
+    override suspend fun postLogin(
+        accessToken: String,
+        loginRequest: LoginRequestEntity
+    ): Result<LoginResponseEntity> = runCatching {
+        loginDataSource.postLogin(
+            accessToken,
+            loginRequest.toLoginRequestDto(),
+        ).data.toLoginEntity()
+    }
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/data/login/service/LoginService.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/data/login/service/LoginService.kt
@@ -1,0 +1,16 @@
+package com.coinkiri.coinkiri.data.login.service
+
+import com.coinkiri.coinkiri.core.network.BaseResponse
+import com.coinkiri.coinkiri.data.login.dto.request.LoginRequestDto
+import com.coinkiri.coinkiri.data.login.dto.response.LoginResponseDto
+import retrofit2.http.Body
+import retrofit2.http.Header
+import retrofit2.http.POST
+
+interface LoginService {
+    @POST("api/v1/auth/login")
+    suspend fun postLogin(
+        @Header("Authorization") accessToken: String,
+        @Body body: LoginRequestDto,
+    ): BaseResponse<LoginResponseDto>
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/data/reissuetoken/datasource/ReissueTokenDataSource.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/data/reissuetoken/datasource/ReissueTokenDataSource.kt
@@ -1,0 +1,11 @@
+package com.coinkiri.coinkiri.data.reissuetoken.datasource
+
+import com.coinkiri.coinkiri.core.network.BaseResponse
+import com.coinkiri.coinkiri.data.reissuetoken.response.ReissueTokenResponseDto
+
+interface ReissueTokenDataSource {
+
+    suspend fun postReissueToken(
+        refreshToken: String
+    ): BaseResponse<ReissueTokenResponseDto>
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/data/reissuetoken/datasourceimpl/ReissueTokenDataSourceImpl.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/data/reissuetoken/datasourceimpl/ReissueTokenDataSourceImpl.kt
@@ -1,0 +1,17 @@
+package com.coinkiri.coinkiri.data.reissuetoken.datasourceimpl
+
+import com.coinkiri.coinkiri.core.network.BaseResponse
+import com.coinkiri.coinkiri.data.reissuetoken.datasource.ReissueTokenDataSource
+import com.coinkiri.coinkiri.data.reissuetoken.response.ReissueTokenResponseDto
+import com.coinkiri.coinkiri.data.reissuetoken.service.ReissueTokenService
+import javax.inject.Inject
+
+class ReissueTokenDataSourceImpl @Inject constructor(
+    private val reissueTokenService: ReissueTokenService
+) : ReissueTokenDataSource {
+
+    override suspend fun postReissueToken(
+        refreshToken: String
+    ): BaseResponse<ReissueTokenResponseDto> =
+        reissueTokenService.postReissueToken(refreshToken)
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/data/reissuetoken/di/DataSourceModule.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/data/reissuetoken/di/DataSourceModule.kt
@@ -1,0 +1,18 @@
+package com.coinkiri.coinkiri.data.reissuetoken.di
+
+import com.coinkiri.coinkiri.data.reissuetoken.datasource.ReissueTokenDataSource
+import com.coinkiri.coinkiri.data.reissuetoken.datasourceimpl.ReissueTokenDataSourceImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class DataSourceModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindReissueTokenDataSource(reissueTokenDataSourceImpl: ReissueTokenDataSourceImpl): ReissueTokenDataSource
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/data/reissuetoken/di/ReissueTokenRepositoryModule.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/data/reissuetoken/di/ReissueTokenRepositoryModule.kt
@@ -1,0 +1,18 @@
+package com.coinkiri.coinkiri.data.reissuetoken.di
+
+import com.coinkiri.coinkiri.data.reissuetoken.repositoryimpl.ReissueTokenRepositoryImpl
+import com.coinkiri.coinkiri.domain.reissuetoken.repository.ReissueTokenRepository
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class ReissueTokenRepositoryModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindReissueTokenRepository(reissueTokenRepositoryImpl: ReissueTokenRepositoryImpl): ReissueTokenRepository
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/data/reissuetoken/di/ServiceModule.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/data/reissuetoken/di/ServiceModule.kt
@@ -1,0 +1,20 @@
+package com.coinkiri.coinkiri.data.reissuetoken.di
+
+import com.coinkiri.coinkiri.core.network.REISSUE
+import com.coinkiri.coinkiri.data.reissuetoken.service.ReissueTokenService
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object ServiceModule {
+
+    @Provides
+    @Singleton
+    fun provideReissueTokenService(@REISSUE retrofit: Retrofit): ReissueTokenService =
+        retrofit.create(ReissueTokenService::class.java)
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/data/reissuetoken/repositoryimpl/ReissueTokenRepositoryImpl.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/data/reissuetoken/repositoryimpl/ReissueTokenRepositoryImpl.kt
@@ -1,0 +1,20 @@
+package com.coinkiri.coinkiri.data.reissuetoken.repositoryimpl
+
+import com.coinkiri.coinkiri.data.reissuetoken.datasource.ReissueTokenDataSource
+import com.coinkiri.coinkiri.domain.reissuetoken.entity.ReissueTokenResponseEntity
+import com.coinkiri.coinkiri.domain.reissuetoken.repository.ReissueTokenRepository
+import javax.inject.Inject
+
+class ReissueTokenRepositoryImpl @Inject constructor(
+    private val reissueTokenDataSource: ReissueTokenDataSource
+) : ReissueTokenRepository {
+
+    override suspend fun postReissueToken(
+        refreshToken: String,
+    ): Result<ReissueTokenResponseEntity> =
+        runCatching {
+            reissueTokenDataSource.postReissueToken(
+                refreshToken,
+            ).data.toReissueTokenResponseEntity()
+        }
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/data/reissuetoken/response/ReissueTokenResponseDto.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/data/reissuetoken/response/ReissueTokenResponseDto.kt
@@ -1,0 +1,19 @@
+package com.coinkiri.coinkiri.data.reissuetoken.response
+
+import com.coinkiri.coinkiri.domain.reissuetoken.entity.ReissueTokenResponseEntity
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ReissueTokenResponseDto(
+    @SerialName("accessToken")
+    val accessToken: String,
+    @SerialName("refreshToken")
+    val refreshToken: String
+) {
+    fun toReissueTokenResponseEntity() =
+        ReissueTokenResponseEntity(
+            accessToken = accessToken,
+            refreshToken = refreshToken
+        )
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/data/reissuetoken/service/ReissueTokenService.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/data/reissuetoken/service/ReissueTokenService.kt
@@ -1,0 +1,13 @@
+package com.coinkiri.coinkiri.data.reissuetoken.service
+
+import com.coinkiri.coinkiri.core.network.BaseResponse
+import com.coinkiri.coinkiri.data.reissuetoken.response.ReissueTokenResponseDto
+import retrofit2.http.Header
+import retrofit2.http.POST
+
+interface ReissueTokenService {
+    @POST("/api/v1/auth/reissue")
+    suspend fun postReissueToken(
+        @Header("Authorization") refreshToken: String
+    ): BaseResponse<ReissueTokenResponseDto>
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/data/token/di/TokenRepositoryModule.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/data/token/di/TokenRepositoryModule.kt
@@ -1,0 +1,18 @@
+package com.coinkiri.coinkiri.data.token.di
+
+import com.coinkiri.coinkiri.data.token.repositoryimpl.TokenRepositoryImpl
+import com.coinkiri.coinkiri.domain.token.repository.TokenRepository
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class TokenRepositoryModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindTokenRepository(tokenRepositoryImpl: TokenRepositoryImpl): TokenRepository
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/data/token/repositoryimpl/TokenRepositoryImpl.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/data/token/repositoryimpl/TokenRepositoryImpl.kt
@@ -1,0 +1,29 @@
+package com.coinkiri.coinkiri.data.token.repositoryimpl
+
+import com.coinkiri.coinkiri.core.datastore.TokenDataStore
+import com.coinkiri.coinkiri.domain.token.repository.TokenRepository
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.runBlocking
+import javax.inject.Inject
+
+class TokenRepositoryImpl @Inject constructor(
+    private val tokenDataStore: TokenDataStore
+) : TokenRepository {
+
+    override fun getAccessToken(): String = runBlocking {
+        tokenDataStore.accessTokenFlow.firstOrNull().orEmpty()
+    }
+
+    override fun getRefreshToken(): String = runBlocking {
+        tokenDataStore.refreshTokenFlow.firstOrNull().orEmpty()
+    }
+
+    override fun setTokens(accessToken: String, refreshToken: String) = runBlocking {
+        tokenDataStore.setAccessToken(accessToken)
+        tokenDataStore.setRefreshToken(refreshToken)
+    }
+
+    override fun clearInfo() = runBlocking {
+        tokenDataStore.clearInfo()
+    }
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/domain/login/entity/reponse/LoginResponseEntity.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/domain/login/entity/reponse/LoginResponseEntity.kt
@@ -1,0 +1,6 @@
+package com.coinkiri.coinkiri.domain.login.entity.reponse
+
+data class LoginResponseEntity(
+    val accessToken: String,
+    val refreshToken: String
+)

--- a/app/src/main/java/com/coinkiri/coinkiri/domain/login/entity/request/LoginRequestEntity.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/domain/login/entity/request/LoginRequestEntity.kt
@@ -1,0 +1,5 @@
+package com.coinkiri.coinkiri.domain.login.entity.request
+
+data class LoginRequestEntity(
+    val platform: String
+)

--- a/app/src/main/java/com/coinkiri/coinkiri/domain/login/repository/LoginRepository.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/domain/login/repository/LoginRepository.kt
@@ -1,0 +1,11 @@
+package com.coinkiri.coinkiri.domain.login.repository
+
+import com.coinkiri.coinkiri.domain.login.entity.reponse.LoginResponseEntity
+import com.coinkiri.coinkiri.domain.login.entity.request.LoginRequestEntity
+
+interface LoginRepository {
+    suspend fun postLogin(
+        accessToken: String,
+        loginRequest: LoginRequestEntity
+    ): Result<LoginResponseEntity>
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/domain/reissuetoken/entity/ReissueTokenResponseEntity.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/domain/reissuetoken/entity/ReissueTokenResponseEntity.kt
@@ -1,0 +1,6 @@
+package com.coinkiri.coinkiri.domain.reissuetoken.entity
+
+data class ReissueTokenResponseEntity(
+    val accessToken: String,
+    val refreshToken: String
+)

--- a/app/src/main/java/com/coinkiri/coinkiri/domain/reissuetoken/repository/ReissueTokenRepository.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/domain/reissuetoken/repository/ReissueTokenRepository.kt
@@ -1,0 +1,9 @@
+package com.coinkiri.coinkiri.domain.reissuetoken.repository
+
+import com.coinkiri.coinkiri.domain.reissuetoken.entity.ReissueTokenResponseEntity
+
+interface ReissueTokenRepository {
+    suspend fun postReissueToken(
+        refreshToken: String,
+    ): Result<ReissueTokenResponseEntity>
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/domain/token/repository/TokenRepository.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/domain/token/repository/TokenRepository.kt
@@ -1,0 +1,12 @@
+package com.coinkiri.coinkiri.domain.token.repository
+
+interface TokenRepository {
+
+    fun getAccessToken(): String
+
+    fun getRefreshToken(): String
+
+    fun setTokens(accessToken: String, refreshToken: String)
+
+    fun clearInfo()
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/designsystem/theme/Color.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/designsystem/theme/Color.kt
@@ -32,4 +32,4 @@ val Black = Color(0xFF000000)
 
 // login btn
 val Kakao = Color(0XFFFEE500)
-val Naver = Color(0xFF30C135)
+val Naver = Color(0xFF03C75A)

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/designsystem/theme/Color.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/designsystem/theme/Color.kt
@@ -31,5 +31,5 @@ val Gray900 = Color(0xFF111111)
 val Black = Color(0xFF000000)
 
 // login btn
-val Kakao = Color(0XFFFFEB33)
+val Kakao = Color(0XFFFEE500)
 val Naver = Color(0xFF30C135)

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/login/LoginScreen.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/login/LoginScreen.kt
@@ -9,13 +9,17 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.flowWithLifecycle
 import com.coinkiri.coinkiri.R
 import com.coinkiri.coinkiri.ui.designsystem.theme.Black
 import com.coinkiri.coinkiri.ui.designsystem.theme.CoinkiriTheme
@@ -24,20 +28,59 @@ import com.coinkiri.coinkiri.ui.designsystem.theme.Naver
 import com.coinkiri.coinkiri.ui.designsystem.theme.SemiBlue
 import com.coinkiri.coinkiri.ui.designsystem.theme.White
 import com.coinkiri.coinkiri.ui.login.component.LoginBtn
+import kotlinx.coroutines.flow.collectLatest
 
 @Composable
-fun LoginScreen() {
+fun LoginRoute(
+    navigateToHome: () -> Unit,
+) {
+    val viewModel: LoginViewModel = hiltViewModel()
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    LaunchedEffect(viewModel.loginSideEffects, lifecycleOwner) {
+        viewModel.loginSideEffects
+            .flowWithLifecycle(lifecycleOwner.lifecycle)
+            .collectLatest { sideEffect ->
+                when (sideEffect) {
+                    is LoginSideEffect.LoginSuccess -> {
+                        navigateToHome()
+                    }
+
+                    is LoginSideEffect.LoginError -> {
+                        /* TODO : LoginError 필요시 추가 동작 */
+                    }
+                }
+            }
+    }
+
+    LoginScreen(
+        onKakaoBtnClick = { viewModel.startKakaoTalkLogin() },
+        onNaverBtnClick = { /*TODO : naver 로그인 추가*/ }
+    )
+}
+
+@Composable
+fun LoginScreen(
+    onKakaoBtnClick: () -> Unit,
+    onNaverBtnClick: () -> Unit
+) {
     Column(
         modifier = Modifier
             .fillMaxSize()
             .background(SemiBlue)
     ) {
-        LoginScreenContent()
+        LoginScreenContent(
+            onNaverBtnClick = onNaverBtnClick,
+            onKakaoBtnClick = onKakaoBtnClick
+        )
     }
 }
 
 @Composable
-private fun LoginScreenContent() {
+private fun LoginScreenContent(
+    onKakaoBtnClick: () -> Unit,
+    onNaverBtnClick: () -> Unit,
+) {
     Column(
         verticalArrangement = Arrangement.SpaceEvenly,
         modifier = Modifier
@@ -57,44 +100,35 @@ private fun LoginScreenContent() {
             painter = painterResource(id = R.drawable.img_coinkiri_app_icon),
             contentDescription = "app icon"
         )
-        LoginBtnSection(
-            onKakaoBtnClick = { /*TODO 카카오 로그인 구현하기*/ },
-            onNaverBtnClick = { /*TODO 네이버 로그인 구현하기*/ }
-        )
+        Column(
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            LoginBtn(
+                onLoginBtnClick = onKakaoBtnClick,
+                text = R.string.kakao_login,
+                image = R.drawable.img_login_kakao,
+                btnColor = Kakao,
+                textColor = Black
+            )
+
+            LoginBtn(
+                onLoginBtnClick = onNaverBtnClick,
+                text = R.string.naver_login,
+                image = R.drawable.img_login_naver,
+                btnColor = Naver,
+                textColor = White
+            )
+        }
     }
 }
-
-@Composable
-private fun LoginBtnSection(
-    onKakaoBtnClick: () -> Unit,
-    onNaverBtnClick: () -> Unit,
-) {
-    Column(
-        verticalArrangement = Arrangement.spacedBy(10.dp)
-    ) {
-        LoginBtn(
-            onLoginBtnClick = onKakaoBtnClick,
-            text = R.string.kakao_login,
-            image = R.drawable.img_login_kakao,
-            btnColor = Kakao,
-            textColor = Black
-        )
-
-        LoginBtn(
-            onLoginBtnClick = onNaverBtnClick,
-            text = R.string.naver_login,
-            image = R.drawable.img_login_naver,
-            btnColor = Naver,
-            textColor = White
-        )
-    }
-}
-
 
 @Preview
 @Composable
-fun LoginScreenPreview() {
+private fun LoginScreenPreview() {
     CoinkiriTheme {
-        LoginScreen()
+        LoginScreen(
+            onKakaoBtnClick = {},
+            onNaverBtnClick = {}
+        )
     }
 }

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/login/LoginSideEffect.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/login/LoginSideEffect.kt
@@ -1,0 +1,6 @@
+package com.coinkiri.coinkiri.ui.login
+
+sealed class LoginSideEffect {
+    data class LoginSuccess(val accessToken: String) : LoginSideEffect()
+    data class LoginError(val errorMessage: String) : LoginSideEffect()
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/login/LoginViewModel.kt
@@ -1,0 +1,94 @@
+package com.coinkiri.coinkiri.ui.login
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.coinkiri.coinkiri.domain.login.entity.request.LoginRequestEntity
+import com.coinkiri.coinkiri.domain.login.repository.LoginRepository
+import com.coinkiri.coinkiri.domain.token.repository.TokenRepository
+import com.kakao.sdk.auth.model.OAuthToken
+import com.kakao.sdk.common.model.ClientError
+import com.kakao.sdk.common.model.ClientErrorCause
+import com.kakao.sdk.user.UserApiClient
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class LoginViewModel @Inject constructor(
+    private val loginRepository: LoginRepository,
+    private val tokenRepository: TokenRepository,
+    @ApplicationContext private val context: Context
+) : ViewModel() {
+
+    private val _loginSideEffects = MutableSharedFlow<LoginSideEffect>()
+    val loginSideEffects: SharedFlow<LoginSideEffect>
+        get() = _loginSideEffects
+
+    fun startKakaoTalkLogin() {
+        if (UserApiClient.instance.isKakaoTalkLoginAvailable(context)) {
+            UserApiClient.instance.loginWithKakaoTalk(context) { token, error ->
+                handleLoginResult(token, error)
+            }
+        } else {
+            UserApiClient.instance.loginWithKakaoAccount(context) { token, error ->
+                handleLoginResult(token, error)
+            }
+        }
+    }
+
+    private fun handleLoginResult(token: OAuthToken?, error: Throwable?) {
+        viewModelScope.launch {
+            if (error != null) {
+                if (error is ClientError && error.reason == ClientErrorCause.Cancelled) {
+                    handleLoginError("로그인 취소")
+                } else {
+                    handleLoginError("카카오톡 로그인 실패: ${error.localizedMessage}")
+                    startKakaoAccountLogin()
+                }
+            } else if (token != null) {
+                sendTokenToServer(token.accessToken, KAKAO)
+            }
+        }
+    }
+
+    private fun startKakaoAccountLogin() {
+        UserApiClient.instance.loginWithKakaoAccount(context) { token, error ->
+            handleLoginResult(token, error)
+        }
+    }
+
+    private fun sendTokenToServer(
+        accessToken: String,
+        platform: String
+    ) {
+        viewModelScope.launch {
+            loginRepository.postLogin(accessToken, LoginRequestEntity(platform))
+                .onSuccess { response ->
+                    tokenRepository.setTokens(response.accessToken, response.refreshToken)
+                    _loginSideEffects.emit(
+                        LoginSideEffect.LoginSuccess(
+                            response.accessToken
+                        )
+                    )
+                }.onFailure { throwable ->
+                    val errorMessage = throwable.localizedMessage ?: "Unknown error"
+                    handleLoginError(errorMessage)
+                }
+        }
+    }
+
+    private fun handleLoginError(errorMessage: String) {
+        viewModelScope.launch {
+            _loginSideEffects.emit(LoginSideEffect.LoginError(errorMessage))
+        }
+    }
+
+    companion object {
+        const val KAKAO = "KAKAO"
+        const val NAVER = "NAVER"
+    }
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/login/component/LoginBtn.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/login/component/LoginBtn.kt
@@ -45,7 +45,7 @@ fun LoginBtn(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.Center,
             modifier = Modifier
-                .height(45.dp)
+                .height(55.dp)
                 .fillMaxWidth()
 
         ) {

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/login/component/LoginBtn.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/login/component/LoginBtn.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -69,7 +68,7 @@ fun LoginBtn(
 
 @Preview
 @Composable
-fun KakaoLoginBtnPreview() {
+private fun KakaoLoginBtnPreview() {
     CoinkiriTheme {
         LoginBtn(
             text = R.string.kakao_login,
@@ -83,7 +82,7 @@ fun KakaoLoginBtnPreview() {
 
 @Preview
 @Composable
-fun NaverLoginBtnPreview() {
+private fun NaverLoginBtnPreview() {
     CoinkiriTheme {
         LoginBtn(
             text = R.string.naver_login,

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/main/MainActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import com.coinkiri.coinkiri.ui.designsystem.theme.CoinkiriTheme
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -12,6 +13,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+        installSplashScreen().setKeepOnScreenCondition { false }
         setContent {
             CoinkiriTheme {
                 val navigator: ScreenNavigator = rememberScreenNavigator()

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/main/MainScreen.kt
@@ -50,7 +50,26 @@ private fun MainScreenContent(
 private fun NavGraphBuilder.splashScreen(navigator: ScreenNavigator) {
     composable(Route.SplashScreen.routeName) {
         SplashScreen(
-            goHome = { navigator.navigateHome() }
+            navigateToHome = {
+                val navOptions = navOptions {
+                    popUpTo(navigator.navController.graph.findStartDestination().id) {
+                        inclusive = true
+                    }
+                    launchSingleTop = true
+                }
+                navigator.navigateToHome(navOptions = navOptions)
+            },
+            navigateToLogIn = {
+                val navOptions = navOptions {
+                    popUpTo(navigator.navController.graph.findStartDestination().id) {
+                        inclusive = true
+                    }
+                    launchSingleTop = true
+                }
+                navigator.navigateToLogin(
+                    navOptions = navOptions
+                )
+            }
         )
     }
 }

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/main/MainScreen.kt
@@ -4,11 +4,14 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.navOptions
 import com.coinkiri.coinkiri.ui.coin.CoinScreen
 import com.coinkiri.coinkiri.ui.home.HomeScreen
+import com.coinkiri.coinkiri.ui.login.LoginRoute
 import com.coinkiri.coinkiri.ui.profile.ProfileScreen
 import com.coinkiri.coinkiri.ui.splash.SplashScreen
 import com.coinkiri.coinkiri.ui.talk.TalkScreen
@@ -39,6 +42,7 @@ private fun MainScreenContent(
             coinScreen(navigator)
             talkScreen(navigator)
             profileScreen(navigator)
+            loginRoute(navigator)
         }
     }
 }
@@ -58,6 +62,22 @@ private fun NavGraphBuilder.homeScreen(navigator: ScreenNavigator) {
             onTalkClick = { navigator.navigateTalk() },
             onPriceClick = { navigator.navigateCoin() },
             onBookClick = { }
+        )
+    }
+}
+
+private fun NavGraphBuilder.loginRoute(navigator: ScreenNavigator) {
+    composable(Route.LoginScreen.routeName) {
+        LoginRoute(
+            navigateToHome = {
+                val navOptions = navOptions {
+                    popUpTo(navigator.navController.graph.findStartDestination().id) {
+                        inclusive = true
+                    }
+                    launchSingleTop = true
+                }
+                navigator.navigateToHome(navOptions = navOptions)
+            }
         )
     }
 }

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/main/ScreenNavigator.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/main/ScreenNavigator.kt
@@ -12,11 +12,17 @@ class ScreenNavigator(
 ) {
     val startDestination = Route.SplashScreen.routeName
 
-    fun navigateHome() {
-        navController.navigate(Route.HomeScreen.routeName)
     fun navigateToHome(navOptions: NavOptions) =
         navController.navigate(Route.HomeScreen.routeName, navOptions)
 
+    fun navigateToLogin(navOptions: NavOptions? = null) {
+        val options = navOptions ?: navOptions {
+            popUpTo(navController.graph.startDestinationId) {
+                inclusive = false
+            }
+            launchSingleTop = true
+        }
+        navController.navigate(Route.LoginScreen.routeName, options)
     }
 
     fun navigateCoin() {

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/main/ScreenNavigator.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/main/ScreenNavigator.kt
@@ -3,7 +3,9 @@ package com.coinkiri.coinkiri.ui.main
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.navigation.NavHostController
+import androidx.navigation.NavOptions
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navOptions
 
 class ScreenNavigator(
     val navController: NavHostController
@@ -12,6 +14,9 @@ class ScreenNavigator(
 
     fun navigateHome() {
         navController.navigate(Route.HomeScreen.routeName)
+    fun navigateToHome(navOptions: NavOptions) =
+        navController.navigate(Route.HomeScreen.routeName, navOptions)
+
     }
 
     fun navigateCoin() {

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/splash/SplashScreen.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/splash/SplashScreen.kt
@@ -16,12 +16,14 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.flowWithLifecycle
 import com.coinkiri.coinkiri.R
 import com.coinkiri.coinkiri.ui.designsystem.theme.CoinkiriTheme
 import com.coinkiri.coinkiri.ui.designsystem.theme.Gray500
@@ -31,12 +33,25 @@ import kotlinx.coroutines.delay
 
 @Composable
 fun SplashScreen(
-    goHome: () -> Unit,
+    navigateToHome: (Boolean) -> Unit,
+    navigateToLogIn: () -> Unit,
+    viewModel: SplashViewModel = hiltViewModel(),
 ) {
 
+    val lifecycleOwner = LocalLifecycleOwner.current
+
     LaunchedEffect(Unit) {
-        delay(1200L)
-        goHome()
+        viewModel.showSplash()
+    }
+
+    LaunchedEffect(viewModel.sideEffects, lifecycleOwner) {
+        viewModel.sideEffects.flowWithLifecycle(lifecycle = lifecycleOwner.lifecycle)
+            .collect { sideEffect ->
+                when (sideEffect) {
+                    is SplashSideEffect.NavigateToHome -> navigateToHome(true)
+                    is SplashSideEffect.NavigateLogin -> navigateToLogIn()
+                }
+            }
     }
 
     Column(
@@ -82,7 +97,8 @@ fun SplashScreen(
 private fun SplashScreenPreview() {
     CoinkiriTheme {
         SplashScreen(
-            goHome = {}
+            navigateToHome = {},
+            navigateToLogIn = {}
         )
     }
 }

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/splash/SplashSideEffect.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/splash/SplashSideEffect.kt
@@ -1,0 +1,6 @@
+package com.coinkiri.coinkiri.ui.splash
+
+sealed class SplashSideEffect {
+    data object NavigateLogin : SplashSideEffect()
+    data object NavigateToHome : SplashSideEffect()
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/splash/SplashViewModel.kt
@@ -1,0 +1,43 @@
+package com.coinkiri.coinkiri.ui.splash
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.coinkiri.coinkiri.core.datastore.TokenDataStore
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class SplashViewModel @Inject constructor(
+    private val tokenDataStore: TokenDataStore
+) : ViewModel() {
+
+    private val _sideEffects = MutableSharedFlow<SplashSideEffect>()
+    val sideEffects: SharedFlow<SplashSideEffect> get() = _sideEffects.asSharedFlow()
+
+    fun showSplash() {
+        viewModelScope.launch {
+            delay(SPLASH_DURATION)
+            checkIsLogined()
+        }
+    }
+
+    private suspend fun checkIsLogined() {
+        val accessToken = tokenDataStore.accessTokenFlow.firstOrNull().orEmpty()
+        val isLogined = accessToken.isNotEmpty()
+        if (isLogined) {
+            _sideEffects.emit(SplashSideEffect.NavigateToHome)
+        } else {
+            _sideEffects.emit(SplashSideEffect.NavigateLogin)
+        }
+    }
+
+    companion object {
+        const val SPLASH_DURATION = 1200L
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.jvm) apply false
+    alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.compose.complier) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.hilt) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,9 @@ ksp = "2.0.0-1.0.23"
 hilt = "2.52"
 hiltNavigationCompose = "1.2.0"
 
+## Kakao
+kakaoLogin = "2.20.3"
+
 ## Test
 junit = "4.13.2"
 androidx-test-junit = "1.2.1"
@@ -47,6 +50,8 @@ compose-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
 hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hilt" }
 hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
+
+kakao-v2-user = { module = "com.kakao.sdk:v2-user", version.ref = "kakaoLogin" }
 
 junit = { module = "junit:junit", version.ref = "junit" }
 androidx-test-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-test-junit" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ androidGradlePlugin = "8.5.1"
 
 ## Kotlin
 kotlin = "2.0.0"
+kotlinxSerializationJson = "1.7.0"
 
 ## AndroidX
 androidxCore = "1.13.1"
@@ -53,6 +54,7 @@ hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt"
 hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hilt" }
 hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
 
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 kakao-v2-user = { module = "com.kakao.sdk:v2-user", version.ref = "kakaoLogin" }
 
 junit = { module = "junit:junit", version.ref = "junit" }
@@ -75,6 +77,7 @@ compose = [
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 compose-complier = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
-hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
+hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ androidxCore = "1.13.1"
 lifecycleRuntimeKtx = "2.8.4"
 navigationRuntimeKtx = "2.7.7"
 activityCompose = "1.9.1"
+androidxDatastore = "1.1.1"
 
 ## Compose
 composeBom = "2024.06.00"
@@ -34,6 +35,7 @@ androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx
 androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 androidx-navigation-runtime-ktx = { module = "androidx.navigation:navigation-runtime-ktx", version.ref = "navigationRuntimeKtx" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
+androidx-datastore = { module = "androidx.datastore:datastore-preferences", version.ref = "androidxDatastore" }
 
 compose-bom = { module = "androidx.compose:compose-bom", version.ref = "composeBom" }
 compose-ui = { module = "androidx.compose.ui:ui" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ androidxCore = "1.13.1"
 lifecycleRuntimeKtx = "2.8.4"
 navigationRuntimeKtx = "2.7.7"
 activityCompose = "1.9.1"
+androidxCoreSplash = "1.0.1"
 androidxDatastore = "1.1.1"
 
 ## Compose
@@ -46,6 +47,7 @@ androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx
 androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 androidx-navigation-runtime-ktx = { module = "androidx.navigation:navigation-runtime-ktx", version.ref = "navigationRuntimeKtx" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
+androidx-core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "androidxCoreSplash" }
 androidx-datastore = { module = "androidx.datastore:datastore-preferences", version.ref = "androidxDatastore" }
 
 compose-bom = { module = "androidx.compose:compose-bom", version.ref = "composeBom" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,12 @@ hiltNavigationCompose = "1.2.0"
 okhttp = "4.12.0"
 retrofit = "2.11.0"
 
+## Timber
+timber = "5.0.1"
+
+## Phoenix
+phoenix = "3.0.0"
+
 ## Kakao
 kakaoLogin = "2.20.3"
 
@@ -65,6 +71,10 @@ retrofit-core = { module = "com.squareup.retrofit2:retrofit", version.ref = "ret
 retrofit-kotlin-serialization = { module = "com.squareup.retrofit2:converter-kotlinx-serialization", version.ref = "retrofit" }
 
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
+
+timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
+process-phoenix = { module = "com.jakewharton:process-phoenix", version.ref = "phoenix" }
+
 kakao-v2-user = { module = "com.kakao.sdk:v2-user", version.ref = "kakaoLogin" }
 
 junit = { module = "junit:junit", version.ref = "junit" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 ## Android gradle plugin
-androidGradlePlugin = "8.5.1"
+androidGradlePlugin = "8.5.2"
 
 ## Kotlin
 kotlin = "2.0.0"
@@ -8,14 +8,14 @@ kotlinxSerializationJson = "1.7.0"
 
 ## AndroidX
 androidxCore = "1.13.1"
-lifecycleRuntimeKtx = "2.8.4"
-navigationRuntimeKtx = "2.7.7"
-activityCompose = "1.9.1"
+androidxLifecycle = "2.8.4"
+androidxNavigation = "2.7.7"
+androidxActivity = "1.9.1"
 androidxCoreSplash = "1.0.1"
 androidxDatastore = "1.1.1"
 
 ## Compose
-composeBom = "2024.06.00"
+composeBom = "2024.08.00"
 
 ## Kotlin Symbol Processing
 ksp = "2.0.0-1.0.23"
@@ -44,9 +44,9 @@ androidx-test-espresso = "3.6.1"
 
 [libraries]
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidxCore" }
-androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
-androidx-navigation-runtime-ktx = { module = "androidx.navigation:navigation-runtime-ktx", version.ref = "navigationRuntimeKtx" }
-androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
+androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidxLifecycle" }
+androidx-navigation-runtime-ktx = { module = "androidx.navigation:navigation-runtime-ktx", version.ref = "androidxNavigation" }
+androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidxActivity" }
 androidx-core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "androidxCoreSplash" }
 androidx-datastore = { module = "androidx.datastore:datastore-preferences", version.ref = "androidxDatastore" }
 
@@ -112,4 +112,4 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 compose-complier = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
-hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
+hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,10 @@ ksp = "2.0.0-1.0.23"
 hilt = "2.52"
 hiltNavigationCompose = "1.2.0"
 
+## Network
+okhttp = "4.12.0"
+retrofit = "2.11.0"
+
 ## Kakao
 kakaoLogin = "2.20.3"
 
@@ -54,6 +58,12 @@ hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt"
 hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hilt" }
 hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
 
+okhttp-bom = { module = "com.squareup.okhttp3:okhttp-bom", version.ref = "okhttp" }
+okhttp = { module = "com.squareup.okhttp3:okhttp" }
+okhttp-logging = { module = "com.squareup.okhttp3:logging-interceptor" }
+retrofit-core = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
+retrofit-kotlin-serialization = { module = "com.squareup.retrofit2:converter-kotlinx-serialization", version.ref = "retrofit" }
+
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 kakao-v2-user = { module = "com.kakao.sdk:v2-user", version.ref = "kakaoLogin" }
 
@@ -71,6 +81,16 @@ compose = [
     "compose-material-three",
     "compose-material-icons",
     "compose-material-icons-extended"
+]
+
+okhttp = [
+    "okhttp",
+    "okhttp-logging"
+]
+
+retrofit = [
+    "retrofit-core",
+    "retrofit-kotlin-serialization"
 ]
 
 [plugins]

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven { url = java.net.URI("https://devrepo.kakao.com/nexus/content/groups/public/") }
     }
 }
 


### PR DESCRIPTION
## 관련 이슈번호

- Closes #23 

## 주요 변경사항
  - 라이브러리 의존성 추가
     - okhttps, retrofit, kotlinx-serialization, timber, datastore, splashscreen
  - data, domain 레이어 추가
  - datastore를 통해 토큰을 관리할 수 있도록 구현
  - network 설정(okhttp 로깅, retrofit 활용)
  - 스플래쉬 화면에서 토큰값 여부에 따라 홈,로그인 화면으로 전환하도록 구현
  - 카카오 로그인 가능하도록 구현

## 📸 Screenshot (optional)

