### PR TITLE
업비트 웹소켓을 통한 실시간 코인가격데이터 수신기능 추가

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -33,6 +33,12 @@ android {
 
         buildConfigField(
             "String",
+            "UPBIT_SOCKET_URL",
+            gradleLocalProperties(rootDir, providers).getProperty("upbitSocketUrl"),
+        )
+
+        buildConfigField(
+            "String",
             "KAKAO_NATIVE_APP_KEY",
             gradleLocalProperties(rootDir, providers).getProperty("kakaoNativeAppKey"),
         )

--- a/app/src/main/java/com/coinkiri/coinkiri/core/network/NetworkModule.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/core/network/NetworkModule.kt
@@ -17,6 +17,7 @@ import retrofit2.Converter
 import retrofit2.Retrofit
 import retrofit2.converter.kotlinx.serialization.asConverterFactory
 import timber.log.Timber
+import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 
 @Module
@@ -80,6 +81,16 @@ object NetworkModule {
         loggingInterceptor: Interceptor,
     ): OkHttpClient = OkHttpClient.Builder()
         .addInterceptor(loggingInterceptor)
+        .build()
+
+    @Provides
+    @Singleton
+    @WEBSOCKET
+    fun provideWebSocketOkHttpClient(
+        loggingInterceptor: Interceptor,
+    ): OkHttpClient = OkHttpClient.Builder()
+        .addInterceptor(loggingInterceptor)
+        .readTimeout(0, TimeUnit.SECONDS)
         .build()
 
     @Provides

--- a/app/src/main/java/com/coinkiri/coinkiri/core/network/Qualifier.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/core/network/Qualifier.kt
@@ -9,3 +9,7 @@ annotation class REISSUE
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class JWT
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class WEBSOCKET

--- a/app/src/main/java/com/coinkiri/coinkiri/core/util/Formatter.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/core/util/Formatter.kt
@@ -1,0 +1,12 @@
+package com.coinkiri.coinkiri.core.util
+
+import java.text.DecimalFormat
+
+object Formatter {
+
+    fun formattedTradePrice(tradePrice: Double?): String =
+        tradePrice?.let { DecimalFormat("#,###").format(it) } ?: "0"
+
+    fun formattedSignedChangeRate(signedChangeRate: Double?): String =
+        String.format("%.2f", signedChangeRate?.times(100) ?: 0.0) + "%"
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/data/coin/dto/response/TickerResponseDto.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/data/coin/dto/response/TickerResponseDto.kt
@@ -1,0 +1,113 @@
+package com.coinkiri.coinkiri.data.coin.dto.response
+
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * 티커에 대한 응답을 나타내는 데이터 전송 객체(DTO).
+ *
+ * @property type 티커의 유형 (예: "ticker").
+ * @property code 암호화폐 쌍의 코드 (예: "KRW-BTC").
+ * @property openingPrice 암호화폐의 시가.
+ * @property highPrice 암호화폐의 고가.
+ * @property lowPrice 암호화폐의 저가.
+ * @property tradePrice 암호화폐의 현재가.
+ * @property prevClosingPrice 전일 종가.
+ * @property accTradePrice 누적 거래대금 (UTC 0시 기준).
+ * @property change 전일 대비 변화 (예: "RISE", "FALL").
+ * @property changePrice 부호 없는 전일 대비 가격 변화.
+ * @property signedChangePrice 전일 대비 가격 변화 (부호 포함).
+ * @property changeRate 전일 대비 가격 변동률.
+ * @property signedChangeRate 전일 대비 가격 변동률 (부호 포함).
+ * @property askBid 매수/매도 구분.
+ * @property tradeVolume 최근 24시간 거래량.
+ * @property accTradeVolume 누적 거래량.
+ * @property tradeDate 최근 거래 일자 (UTC).
+ * @property tradeTime 최근 거래 시각 (UTC).
+ * @property tradeTimestamp 최근 거래 타임스탬프.
+ * @property accAskVolume 누적 매도량.
+ * @property accBidVolume 누적 매수량.
+ * @property highest52WeekPrice 52주 신고가.
+ * @property highest52WeekDate 52주 신고가 달성일.
+ * @property lowest52WeekPrice 52주 신저가.
+ * @property lowest52WeekDate 52주 신저가 달성일.
+ * @property marketState 마켓 상태.
+ * @property isTradingSuspended 거래 정지 여부.
+ * @property delistingDate 상장 폐지일.
+ * @property marketWarning 유의 종목 여부.
+ * @property timestamp 타임스탬프.
+ * @property accTradePrice24h 최근 24시간 누적 거래대금 (UTC 0시 기준).
+ * @property accTradeVolume24h 최근 24시간 누적 거래량 (UTC 0시 기준).
+ * @property streamType 스트림 타입.
+ */
+@Serializable
+data class TickerResponseDto(
+    @SerialName("type")
+    val type: String,
+    @SerialName("code")
+    val code: String,
+    @SerialName("opening_price")
+    val openingPrice: Double?,
+    @SerialName("high_price")
+    val highPrice: Double?,
+    @SerialName("low_price")
+    val lowPrice: Double?,
+    @SerialName("trade_price")
+    val tradePrice: Double?,
+    @SerialName("prev_closing_price")
+    val prevClosingPrice: Double?,
+    @SerialName("acc_trade_price")
+    val accTradePrice: Double?,
+    @SerialName("change")
+    val change: String?,
+    @SerialName("change_price")
+    val changePrice: Double?,
+    @SerialName("signed_change_price")
+    val signedChangePrice: Double?,
+    @SerialName("change_rate")
+    val changeRate: Double?,
+    @SerialName("signed_change_rate")
+    val signedChangeRate: Double?,
+    @SerialName("ask_bid")
+    val askBid: String?,
+    @SerialName("trade_volume")
+    val tradeVolume: Double,
+    @SerialName("acc_trade_volume")
+    val accTradeVolume: Double?,
+    @SerialName("trade_date")
+    val tradeDate: String?,
+    @SerialName("trade_time")
+    val tradeTime: String?,
+    @SerialName("trade_timestamp")
+    val tradeTimestamp: Long?,
+    @SerialName("acc_ask_volume")
+    val accAskVolume: Double?,
+    @SerialName("acc_bid_volume")
+    val accBidVolume: Double?,
+    @SerialName("highest_52_week_price")
+    val highest52WeekPrice: Double?,
+    @SerialName("highest_52_week_date")
+    val highest52WeekDate: String?,
+    @SerialName("lowest_52_week_price")
+    val lowest52WeekPrice: Double?,
+    @SerialName("lowest_52_week_date")
+    val lowest52WeekDate: String?,
+    @SerialName("market_state")
+    val marketState: String?,
+    @SerialName("is_trading_suspended")
+    val isTradingSuspended: Boolean?,
+    @SerialName("delisting_date")
+    @Contextual
+    val delistingDate: Any?,
+    @SerialName("market_warning")
+    val marketWarning: String?,
+    @SerialName("timestamp")
+    val timestamp: Long?,
+    @SerialName("acc_trade_price_24h")
+    val accTradePrice24h: Double?,
+    @SerialName("acc_trade_volume_24h")
+    val accTradeVolume24h: Double?,
+    @SerialName("stream_type")
+    val streamType: String?
+)

--- a/app/src/main/java/com/coinkiri/coinkiri/data/coin/mapper/CoinMapper.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/data/coin/mapper/CoinMapper.kt
@@ -1,7 +1,7 @@
 package com.coinkiri.coinkiri.data.coin.mapper
 
 import com.coinkiri.coinkiri.data.coin.dto.response.CoinResponseDto
-import com.coinkiri.coinkiri.domain.coin.entity.CoinResponseEntity
+import com.coinkiri.coinkiri.domain.coin.entity.response.CoinResponseEntity
 
 fun CoinResponseDto.toCoinEntity(): CoinResponseEntity =
     CoinResponseEntity(

--- a/app/src/main/java/com/coinkiri/coinkiri/data/coin/repositoryimpl/CoinRepositoryImpl.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/data/coin/repositoryimpl/CoinRepositoryImpl.kt
@@ -2,7 +2,7 @@ package com.coinkiri.coinkiri.data.coin.repositoryimpl
 
 import com.coinkiri.coinkiri.data.coin.datasource.CoinDataSource
 import com.coinkiri.coinkiri.data.coin.mapper.toCoinEntity
-import com.coinkiri.coinkiri.domain.coin.entity.CoinResponseEntity
+import com.coinkiri.coinkiri.domain.coin.entity.response.CoinResponseEntity
 import com.coinkiri.coinkiri.domain.coin.repository.CoinRepository
 import javax.inject.Inject
 

--- a/app/src/main/java/com/coinkiri/coinkiri/data/ticker/datasource/TickerDataSource.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/data/ticker/datasource/TickerDataSource.kt
@@ -1,0 +1,10 @@
+package com.coinkiri.coinkiri.data.ticker.datasource
+
+import com.coinkiri.coinkiri.data.ticker.dto.request.TickerRequestDto
+import com.coinkiri.coinkiri.data.ticker.dto.response.TickerResponseDto
+import kotlinx.coroutines.flow.Flow
+
+interface TickerDataSource {
+    fun getTickers(tickerRequestDto: TickerRequestDto): Flow<TickerResponseDto>
+    fun closeConnection()
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/data/ticker/datasourceimpl/TickerDataSourceImpl.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/data/ticker/datasourceimpl/TickerDataSourceImpl.kt
@@ -1,0 +1,20 @@
+package com.coinkiri.coinkiri.data.ticker.datasourceimpl
+
+import com.coinkiri.coinkiri.data.ticker.datasource.TickerDataSource
+import com.coinkiri.coinkiri.data.ticker.dto.request.TickerRequestDto
+import com.coinkiri.coinkiri.data.ticker.dto.response.TickerResponseDto
+import com.coinkiri.coinkiri.data.ticker.service.TickerService
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class TickerDataSourceImpl @Inject constructor(
+    private val tickerService: TickerService,
+) : TickerDataSource {
+
+    override fun getTickers(tickerRequestDto: TickerRequestDto): Flow<TickerResponseDto> =
+        tickerService.startConnection(tickerRequestDto)
+
+    override fun closeConnection() {
+        tickerService.closeConnection()
+    }
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/data/ticker/di/DataSourceModule.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/data/ticker/di/DataSourceModule.kt
@@ -1,0 +1,18 @@
+package com.coinkiri.coinkiri.data.ticker.di
+
+import com.coinkiri.coinkiri.data.ticker.datasource.TickerDataSource
+import com.coinkiri.coinkiri.data.ticker.datasourceimpl.TickerDataSourceImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class DataSourceModule {
+
+    @Binds
+    @Singleton
+    abstract fun provideTickerDataSource(tickerDataSourceImpl: TickerDataSourceImpl): TickerDataSource
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/data/ticker/di/RepositoryModule.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/data/ticker/di/RepositoryModule.kt
@@ -1,0 +1,18 @@
+package com.coinkiri.coinkiri.data.ticker.di
+
+import com.coinkiri.coinkiri.data.ticker.repositoryimpl.TickerRepositoryImpl
+import com.coinkiri.coinkiri.domain.coin.repository.TickerRepository
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class RepositoryModule {
+
+    @Binds
+    @Singleton
+    abstract fun provideTickerRepository(tickerRepositoryImpl: TickerRepositoryImpl): TickerRepository
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/data/ticker/di/ServiceModule.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/data/ticker/di/ServiceModule.kt
@@ -1,0 +1,24 @@
+package com.coinkiri.coinkiri.data.ticker.di
+
+import com.coinkiri.coinkiri.core.network.WEBSOCKET
+import com.coinkiri.coinkiri.data.ticker.service.TickerService
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object ServiceModule {
+
+    @Provides
+    @Singleton
+    fun provideTickerService(
+        @WEBSOCKET okHttpClient: OkHttpClient,
+        json: Json
+    ): TickerService =
+        TickerService(okHttpClient, json)
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/data/ticker/dto/request/TickerRequestDto.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/data/ticker/dto/request/TickerRequestDto.kt
@@ -1,0 +1,6 @@
+package com.coinkiri.coinkiri.data.ticker.dto.request
+
+data class TickerRequestDto(
+    val type: String,
+    val codes: String
+)

--- a/app/src/main/java/com/coinkiri/coinkiri/data/ticker/dto/response/TickerResponseDto.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/data/ticker/dto/response/TickerResponseDto.kt
@@ -1,4 +1,4 @@
-package com.coinkiri.coinkiri.data.coin.dto.response
+package com.coinkiri.coinkiri.data.ticker.dto.response
 
 import kotlinx.serialization.Contextual
 import kotlinx.serialization.SerialName

--- a/app/src/main/java/com/coinkiri/coinkiri/data/ticker/mapper/TickerMapper.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/data/ticker/mapper/TickerMapper.kt
@@ -1,0 +1,19 @@
+package com.coinkiri.coinkiri.data.ticker.mapper
+
+import com.coinkiri.coinkiri.data.ticker.dto.request.TickerRequestDto
+import com.coinkiri.coinkiri.data.ticker.dto.response.TickerResponseDto
+import com.coinkiri.coinkiri.domain.coin.entity.request.TickerRequestEntity
+import com.coinkiri.coinkiri.domain.coin.entity.response.TickerResponseEntity
+
+fun TickerResponseDto.toTickerEntity(): TickerResponseEntity =
+    TickerResponseEntity(
+        code = code,
+        tradePrice = tradePrice,
+        signedChangeRate = signedChangeRate
+    )
+
+fun TickerRequestEntity.toTickerRequestDto(): TickerRequestDto =
+    TickerRequestDto(
+        codes = codes,
+        type = type
+    )

--- a/app/src/main/java/com/coinkiri/coinkiri/data/ticker/repositoryimpl/TickerRepositoryImpl.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/data/ticker/repositoryimpl/TickerRepositoryImpl.kt
@@ -1,0 +1,26 @@
+package com.coinkiri.coinkiri.data.ticker.repositoryimpl
+
+import com.coinkiri.coinkiri.data.ticker.datasource.TickerDataSource
+import com.coinkiri.coinkiri.data.ticker.mapper.toTickerEntity
+import com.coinkiri.coinkiri.data.ticker.mapper.toTickerRequestDto
+import com.coinkiri.coinkiri.domain.coin.entity.request.TickerRequestEntity
+import com.coinkiri.coinkiri.domain.coin.entity.response.TickerResponseEntity
+import com.coinkiri.coinkiri.domain.coin.repository.TickerRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class TickerRepositoryImpl @Inject constructor(
+    private val tickerDataSource: TickerDataSource
+) : TickerRepository {
+
+    override fun getTickers(tickerRequestEntity: TickerRequestEntity): Flow<TickerResponseEntity> =
+        tickerDataSource.getTickers(tickerRequestEntity.toTickerRequestDto())
+            .map { tickerResponseDto ->
+                tickerResponseDto.toTickerEntity()
+            }
+
+    override fun closeConnection() {
+        tickerDataSource.closeConnection()
+    }
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/data/ticker/service/TickerService.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/data/ticker/service/TickerService.kt
@@ -1,0 +1,95 @@
+package com.coinkiri.coinkiri.data.ticker.service
+
+import com.coinkiri.coinkiri.BuildConfig
+import com.coinkiri.coinkiri.core.network.WEBSOCKET
+import com.coinkiri.coinkiri.data.ticker.dto.request.TickerRequestDto
+import com.coinkiri.coinkiri.data.ticker.dto.response.TickerResponseDto
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import okio.ByteString
+import timber.log.Timber
+import java.util.UUID
+import javax.inject.Inject
+
+class TickerService @Inject constructor(
+    @WEBSOCKET private val okHttpClient: OkHttpClient,
+    private val json: Json
+) {
+    private lateinit var webSocket: WebSocket
+
+    fun startConnection(tickerRequestDto: TickerRequestDto): Flow<TickerResponseDto> =
+        callbackFlow {
+            val request = Request.Builder()
+                .url(BuildConfig.UPBIT_SOCKET_URL)
+                .build()
+
+            webSocket = okHttpClient.newWebSocket(
+                request,
+                createWebSocketListener(
+                    tickerRequestDto = tickerRequestDto,
+                    onTickerReceived = { tickerResponseDto ->
+                        trySend(tickerResponseDto).isSuccess
+                    }
+                )
+            )
+
+            awaitClose {
+                closeConnection()
+            }
+        }
+
+    fun closeConnection() {
+        if (this::webSocket.isInitialized) {
+            webSocket.close(CLOSE_CODE, null)
+        }
+    }
+
+    private fun createWebSocketListener(
+        tickerRequestDto: TickerRequestDto,
+        onTickerReceived: (TickerResponseDto) -> Unit,
+    ) = object : WebSocketListener() {
+        override fun onOpen(webSocket: WebSocket, response: Response) {
+            val uniqueTicket = UUID.randomUUID().toString()
+            val json = """
+                        [
+                            {
+                                "ticket":"$uniqueTicket"
+                            },
+                            {
+                                "type":"${tickerRequestDto.type}",
+                                "codes":[
+                                    ${tickerRequestDto.codes}
+                                ]
+                            }
+                        ]
+                """.trimIndent()
+            webSocket.send(json)
+        }
+
+        override fun onMessage(webSocket: WebSocket, bytes: ByteString) {
+            val jsonString = bytes.utf8()
+            val tickerResponseDto = parseResponse(jsonString)
+            onTickerReceived(tickerResponseDto)
+        }
+
+        override fun onClosed(webSocket: WebSocket, code: Int, reason: String) =
+            Timber.d("Socket Closed: $code / $reason")
+
+        override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) =
+            Timber.d("Socket Error: ${t.message}")
+    }
+
+    private fun parseResponse(jsonResponse: String): TickerResponseDto =
+        json.decodeFromString<TickerResponseDto>(jsonResponse)
+
+    private companion object {
+        private const val CLOSE_CODE = 1000
+    }
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/domain/coin/entity/MergedCoinTickerEntity.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/domain/coin/entity/MergedCoinTickerEntity.kt
@@ -1,0 +1,9 @@
+package com.coinkiri.coinkiri.domain.coin.entity
+
+data class MergedCoinTickerEntity(
+    val marketName: String,
+    val koreanName: String,
+    val symbol: String,
+    val tradePrice: Double?,
+    val signedChangeRate: Double?,
+)

--- a/app/src/main/java/com/coinkiri/coinkiri/domain/coin/entity/request/TickerRequestEntity.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/domain/coin/entity/request/TickerRequestEntity.kt
@@ -1,0 +1,6 @@
+package com.coinkiri.coinkiri.domain.coin.entity.request
+
+data class TickerRequestEntity(
+    val type: String,
+    val codes: String
+)

--- a/app/src/main/java/com/coinkiri/coinkiri/domain/coin/entity/response/CoinResponseEntity.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/domain/coin/entity/response/CoinResponseEntity.kt
@@ -1,4 +1,4 @@
-package com.coinkiri.coinkiri.domain.coin.entity
+package com.coinkiri.coinkiri.domain.coin.entity.response
 
 data class CoinResponseEntity(
     val marketName: String,

--- a/app/src/main/java/com/coinkiri/coinkiri/domain/coin/entity/response/TickerResponseEntity.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/domain/coin/entity/response/TickerResponseEntity.kt
@@ -1,0 +1,7 @@
+package com.coinkiri.coinkiri.domain.coin.entity.response
+
+data class TickerResponseEntity(
+    val code: String,
+    val tradePrice: Double?,
+    val signedChangeRate: Double?,
+)

--- a/app/src/main/java/com/coinkiri/coinkiri/domain/coin/repository/CoinRepository.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/domain/coin/repository/CoinRepository.kt
@@ -1,6 +1,6 @@
 package com.coinkiri.coinkiri.domain.coin.repository
 
-import com.coinkiri.coinkiri.domain.coin.entity.CoinResponseEntity
+import com.coinkiri.coinkiri.domain.coin.entity.response.CoinResponseEntity
 
 interface CoinRepository {
     suspend fun getCoinList(): Result<List<CoinResponseEntity>>

--- a/app/src/main/java/com/coinkiri/coinkiri/domain/coin/repository/TickerRepository.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/domain/coin/repository/TickerRepository.kt
@@ -1,0 +1,10 @@
+package com.coinkiri.coinkiri.domain.coin.repository
+
+import com.coinkiri.coinkiri.domain.coin.entity.request.TickerRequestEntity
+import com.coinkiri.coinkiri.domain.coin.entity.response.TickerResponseEntity
+import kotlinx.coroutines.flow.Flow
+
+interface TickerRepository {
+    fun getTickers(tickerRequestEntity: TickerRequestEntity): Flow<TickerResponseEntity>
+    fun closeConnection()
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/domain/coin/usecase/GetCoinListUseCase.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/domain/coin/usecase/GetCoinListUseCase.kt
@@ -1,6 +1,6 @@
 package com.coinkiri.coinkiri.domain.coin.usecase
 
-import com.coinkiri.coinkiri.domain.coin.entity.CoinResponseEntity
+import com.coinkiri.coinkiri.domain.coin.entity.response.CoinResponseEntity
 import com.coinkiri.coinkiri.domain.coin.repository.CoinRepository
 import javax.inject.Inject
 

--- a/app/src/main/java/com/coinkiri/coinkiri/domain/coin/usecase/GetTicketsUseCase.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/domain/coin/usecase/GetTicketsUseCase.kt
@@ -1,0 +1,14 @@
+package com.coinkiri.coinkiri.domain.coin.usecase
+
+import com.coinkiri.coinkiri.domain.coin.entity.request.TickerRequestEntity
+import com.coinkiri.coinkiri.domain.coin.entity.response.TickerResponseEntity
+import com.coinkiri.coinkiri.domain.coin.repository.TickerRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetTicketsUseCase @Inject constructor(
+    private val tickerRepository: TickerRepository
+) {
+    operator fun invoke(tickerRequestEntity: TickerRequestEntity): Flow<TickerResponseEntity> =
+        tickerRepository.getTickers(tickerRequestEntity)
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/coin/CoinScreen.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/coin/CoinScreen.kt
@@ -77,7 +77,7 @@ fun CoinScreenContent(
 @Composable
 fun CoinItems() {
     val viewModel: CoinViewModel = hiltViewModel()
-    val coinList by viewModel.coinList.collectAsState()
+    val coinInfo by viewModel.mergedCoinTickerList.collectAsState()
 
     LaunchedEffect(Unit) {
         viewModel.fetchCoinList()
@@ -86,8 +86,8 @@ fun CoinItems() {
     LazyColumn(
         modifier = Modifier.fillMaxSize()
     ) {
-        items(coinList.size) { index ->
-            val coin = coinList[index]
+        items(coinInfo.size) { index ->
+            val coin = coinInfo[index]
             CoinItem(
                 coin = coin,
                 onCoinItemClick = {}

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/coin/CoinViewModel.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/coin/CoinViewModel.kt
@@ -2,7 +2,7 @@ package com.coinkiri.coinkiri.ui.coin
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.coinkiri.coinkiri.domain.coin.entity.CoinResponseEntity
+import com.coinkiri.coinkiri.domain.coin.entity.response.CoinResponseEntity
 import com.coinkiri.coinkiri.domain.coin.usecase.GetCoinListUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/coin/CoinViewModel.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/coin/CoinViewModel.kt
@@ -3,6 +3,7 @@ package com.coinkiri.coinkiri.ui.coin
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.coinkiri.coinkiri.domain.coin.entity.response.CoinResponseEntity
+import com.coinkiri.coinkiri.domain.coin.entity.MergedCoinTickerEntity
 import com.coinkiri.coinkiri.domain.coin.usecase.GetCoinListUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -12,12 +13,12 @@ import javax.inject.Inject
 
 @HiltViewModel
 class CoinViewModel @Inject constructor(
-    private val getCoinListUseCase: GetCoinListUseCase
+    private val getCoinListUseCase: GetCoinListUseCase,
 ) : ViewModel() {
 
-    private val _coinList = MutableStateFlow<List<CoinResponseEntity>>(emptyList())
-    val coinList: StateFlow<List<CoinResponseEntity>>
-        get() = _coinList
+    private val _mergedCoinTickerList = MutableStateFlow<List<MergedCoinTickerEntity>>(emptyList())
+    val mergedCoinTickerList: StateFlow<List<MergedCoinTickerEntity>>
+        get() = _mergedCoinTickerList
 
     fun fetchCoinList() {
         viewModelScope.launch {
@@ -25,7 +26,16 @@ class CoinViewModel @Inject constructor(
 
             result
                 .onSuccess { coinList ->
-                    _coinList.value = coinList
+                    val initialMergedList = coinList.map { coin ->
+                        MergedCoinTickerEntity(
+                            marketName = coin.marketName,
+                            koreanName = coin.koreanName,
+                            symbol = coin.symbol,
+                            tradePrice = null,
+                            signedChangeRate = null
+                        )
+                    }
+                    _mergedCoinTickerList.value = initialMergedList
                 }
                 .onFailure { exception ->
                     "${exception.message}"

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/coin/CoinViewModel.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/coin/CoinViewModel.kt
@@ -2,9 +2,11 @@ package com.coinkiri.coinkiri.ui.coin
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.coinkiri.coinkiri.domain.coin.entity.response.CoinResponseEntity
 import com.coinkiri.coinkiri.domain.coin.entity.MergedCoinTickerEntity
+import com.coinkiri.coinkiri.domain.coin.entity.request.TickerRequestEntity
+import com.coinkiri.coinkiri.domain.coin.entity.response.TickerResponseEntity
 import com.coinkiri.coinkiri.domain.coin.usecase.GetCoinListUseCase
+import com.coinkiri.coinkiri.domain.coin.usecase.GetTicketsUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -14,6 +16,7 @@ import javax.inject.Inject
 @HiltViewModel
 class CoinViewModel @Inject constructor(
     private val getCoinListUseCase: GetCoinListUseCase,
+    private val getTicketsUseCase: GetTicketsUseCase,
 ) : ViewModel() {
 
     private val _mergedCoinTickerList = MutableStateFlow<List<MergedCoinTickerEntity>>(emptyList())
@@ -36,10 +39,40 @@ class CoinViewModel @Inject constructor(
                         )
                     }
                     _mergedCoinTickerList.value = initialMergedList
+                    fetchTickers()
                 }
                 .onFailure { exception ->
                     "${exception.message}"
                 }
         }
+    }
+
+    private fun fetchTickers() {
+        val marketNames = _mergedCoinTickerList.value.joinToString(",") { "\"${it.marketName}\"" }
+        viewModelScope.launch {
+            getTicketsUseCase(TickerRequestEntity(TYPE, marketNames))
+                .collect { tickerResponseEntity ->
+                    updateTickers(listOf(tickerResponseEntity))
+                }
+        }
+    }
+
+    private fun updateTickers(tickers: List<TickerResponseEntity>) {
+        val updatedList = _mergedCoinTickerList.value.map { mergedCoinTicker ->
+            val matchingTicker = tickers.find { it.code == mergedCoinTicker.marketName }
+            if (matchingTicker != null) {
+                mergedCoinTicker.copy(
+                    tradePrice = matchingTicker.tradePrice,
+                    signedChangeRate = matchingTicker.signedChangeRate
+                )
+            } else {
+                mergedCoinTicker
+            }
+        }
+        _mergedCoinTickerList.value = updatedList
+    }
+
+    companion object {
+        private const val TYPE = "ticker"
     }
 }

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/coin/component/CoinItem.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/coin/component/CoinItem.kt
@@ -17,13 +17,14 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.coinkiri.coinkiri.core.designsystem.theme.CoinkiriTheme
+import com.coinkiri.coinkiri.core.util.Formatter
 import com.coinkiri.coinkiri.core.util.byteArrayToPainter
-import com.coinkiri.coinkiri.domain.coin.entity.response.CoinResponseEntity
+import com.coinkiri.coinkiri.domain.coin.entity.MergedCoinTickerEntity
 
 @Composable
 fun CoinItem(
     onCoinItemClick: () -> Unit,
-    coin: CoinResponseEntity
+    coin: MergedCoinTickerEntity
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -61,11 +62,11 @@ fun CoinItem(
             horizontalAlignment = Alignment.End
         ) {
             Text(
-                text = "₩ 100,000,000",
+                text = "${Formatter.formattedTradePrice(coin.tradePrice)} 원",
                 style = CoinkiriTheme.typography.titleMedium
             )
             Text(
-                text = "+ 12.1%",
+                text = Formatter.formattedSignedChangeRate(coin.signedChangeRate),
                 style = CoinkiriTheme.typography.titleSmall
             )
         }
@@ -79,14 +80,16 @@ fun CoinItem(
 
 @Preview(showBackground = true)
 @Composable
-fun CoinItemPreview() {
+private fun CoinItemPreview() {
     CoinkiriTheme {
         CoinItem(
             onCoinItemClick = {},
-            coin = CoinResponseEntity(
+            coin = MergedCoinTickerEntity(
                 marketName = "",
+                symbol = "",
                 koreanName = "",
-                symbol = ""
+                tradePrice = 0.0,
+                signedChangeRate = 0.0
             )
         )
     }

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/coin/component/CoinItem.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/coin/component/CoinItem.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.coinkiri.coinkiri.core.designsystem.theme.CoinkiriTheme
 import com.coinkiri.coinkiri.core.util.byteArrayToPainter
-import com.coinkiri.coinkiri.domain.coin.entity.CoinResponseEntity
+import com.coinkiri.coinkiri.domain.coin.entity.response.CoinResponseEntity
 
 @Composable
 fun CoinItem(


### PR DESCRIPTION
## 관련 이슈번호

- Closes #33

## 주요 변경사항
- 웹소켓 서비스 구현(업비트 활용)
- 기존 coin의 marketName 목록을 통해 해당 목록 웹소켓 요청을 통해 Ticker수신
- viewmodel의 기존 coin리스트-> Coin,Ticker 병합엔티티 리스트로 변경

## 📸 Screenshot (optional)
![화면 기록 2024-09-03 오전 8 16 05](https://github.com/user-attachments/assets/6ea72682-8b60-4bec-85e2-84b4bbd74b6b)
