### PR TITLE
코인시세 상세보기 화면 ui 구성

### DIFF
--- a/app/src/main/java/com/coinkiri/coinkiri/ui/coin/CoinScreen.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/coin/CoinScreen.kt
@@ -25,7 +25,8 @@ import com.coinkiri.coinkiri.ui.coin.component.CoinSortBar
 
 @Composable
 fun CoinScreen(
-    onBackClick: () -> Unit
+    onBackClick: () -> Unit,
+    onCoinItemClick: () -> Unit
 ) {
     Scaffold(
         topBar = {
@@ -35,7 +36,10 @@ fun CoinScreen(
             )
         },
         content = { innerPadding ->
-            CoinScreenContent(innerPadding)
+            CoinScreenContent(
+                padding = innerPadding,
+                onCoinItemClick = onCoinItemClick
+            )
         }
     )
 }
@@ -56,7 +60,8 @@ private fun CoinScreenTopBar(
 
 @Composable
 fun CoinScreenContent(
-    padding: PaddingValues
+    padding: PaddingValues,
+    onCoinItemClick: () -> Unit
 ) {
     Column(
         modifier = Modifier
@@ -70,12 +75,16 @@ fun CoinScreenContent(
             onSortByCurrentPriceClick = {},
             onSortByChangeRateClick = {}
         )
-        CoinItems()
+        CoinItems(
+            onCoinItemClick = onCoinItemClick
+        )
     }
 }
 
 @Composable
-fun CoinItems() {
+fun CoinItems(
+    onCoinItemClick: () -> Unit
+) {
     val viewModel: CoinViewModel = hiltViewModel()
     val coinInfo by viewModel.mergedCoinTickerList.collectAsState()
 
@@ -90,7 +99,7 @@ fun CoinItems() {
             val coin = coinInfo[index]
             CoinItem(
                 coin = coin,
-                onCoinItemClick = {}
+                onCoinItemClick = onCoinItemClick
             )
         }
     }
@@ -102,6 +111,7 @@ private fun CoinScreenPreview() {
     CoinkiriTheme {
         CoinScreen(
             onBackClick = {},
+            onCoinItemClick = {}
         )
     }
 }

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/coin/component/CoinItem.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/coin/component/CoinItem.kt
@@ -30,7 +30,7 @@ fun CoinItem(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween,
         modifier = Modifier
-            .clickable { onCoinItemClick }
+            .clickable { onCoinItemClick() }
             .padding(vertical = 5.dp, horizontal = 15.dp)
             .fillMaxWidth()
     ) {

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/coindetail/CoinDetailScreen.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/coindetail/CoinDetailScreen.kt
@@ -1,0 +1,81 @@
+package com.coinkiri.coinkiri.ui.coindetail
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.coinkiri.coinkiri.core.designsystem.component.topappbar.CoinkiriTopBar
+import com.coinkiri.coinkiri.core.designsystem.theme.CoinkiriTheme
+import com.coinkiri.coinkiri.core.designsystem.theme.Gray200
+import com.coinkiri.coinkiri.core.designsystem.theme.White
+import com.coinkiri.coinkiri.ui.coindetail.component.CoinChartItem
+import com.coinkiri.coinkiri.ui.coindetail.component.CoinDetailInfoItem
+import com.coinkiri.coinkiri.ui.coindetail.component.NavigateToCoinTalkButton
+
+@Composable
+fun CoinDetailScreen(
+    onBackClick: () -> Unit
+) {
+    Scaffold(
+        topBar = {
+            CoinDetailTopBar(
+                onBackClick = onBackClick
+            )
+        },
+        content = { paddingValues ->
+            CoinDetailContent(
+                padding = paddingValues
+            )
+        }
+    )
+}
+
+@Composable
+private fun CoinDetailTopBar(
+    onBackClick: () -> Unit
+) {
+    CoinkiriTopBar(
+        title = "상세정보",
+        onBackClick = onBackClick,
+        isShowBackButton = true
+    )
+}
+
+@Composable
+private fun CoinDetailContent(
+    padding: PaddingValues
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+        modifier = Modifier
+            .fillMaxSize()
+            .background(White)
+            .padding(padding)
+            .padding(horizontal = 10.dp)
+    ) {
+        CoinDetailInfoItem()
+        HorizontalDivider(color = Gray200)
+        NavigateToCoinTalkButton()
+        CoinChartItem()
+    }
+}
+
+@Preview
+@Composable
+private fun CoinDetailScreenPreview() {
+    CoinkiriTheme {
+        CoinDetailScreen(
+            onBackClick = {}
+        )
+    }
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/coindetail/component/CoinChartItem.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/coindetail/component/CoinChartItem.kt
@@ -1,0 +1,26 @@
+package com.coinkiri.coinkiri.ui.coindetail.component
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.coinkiri.coinkiri.core.designsystem.theme.CoinkiriTheme
+
+@Composable
+fun CoinChartItem() {
+    Column(
+        modifier = Modifier.fillMaxSize()
+    ) {
+        Text(text = "여기 차트")
+    }
+}
+
+@Preview
+@Composable
+private fun CoinChartItemPreview() {
+    CoinkiriTheme {
+        CoinChartItem()
+    }
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/coindetail/component/CoinDetailInfoItem.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/coindetail/component/CoinDetailInfoItem.kt
@@ -1,0 +1,131 @@
+package com.coinkiri.coinkiri.ui.coindetail.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.coinkiri.coinkiri.R
+import com.coinkiri.coinkiri.core.designsystem.theme.CoinkiriTheme
+import com.coinkiri.coinkiri.core.designsystem.theme.Gray500
+
+@Composable
+fun CoinDetailInfoItem() {
+    Row(
+        modifier = Modifier.padding(
+            vertical = 10.dp,
+            horizontal = 10.dp
+        )
+    ) {
+        Image(
+            painter = painterResource(id = R.drawable.btc),
+            contentDescription = "",
+            modifier = Modifier.size(30.dp)
+        )
+        Column(
+            verticalArrangement = Arrangement.spacedBy(13.dp)
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
+                modifier = Modifier.padding(start = 10.dp)
+            ) {
+                Text(
+                    text = "BTC",
+                    style = CoinkiriTheme.typography.titleLarge,
+                )
+                Text(
+                    text = "비트코인",
+                    color = Gray500,
+                    style = CoinkiriTheme.typography.titleLarge,
+                )
+            }
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 10.dp)
+            ) {
+                Text(
+                    text = "100,000,000",
+                    style = CoinkiriTheme.typography.headlineLarge
+                )
+            }
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(20.dp),
+                modifier = Modifier.padding(start = 10.dp)
+            ) {
+                Column() {
+                    Text(
+                        text = "증감률",
+                        color = Gray500,
+                        fontWeight = FontWeight.SemiBold,
+                        style = CoinkiriTheme.typography.labelMedium,
+                    )
+                    Text(
+                        text = "+ 12.4%",
+                        style = CoinkiriTheme.typography.labelMedium,
+                    )
+                }
+                Column() {
+                    Text(
+                        text = "증감액",
+                        color = Gray500,
+                        fontWeight = FontWeight.SemiBold,
+                        style = CoinkiriTheme.typography.labelMedium,
+                    )
+                    Text(
+                        text = "▴ 59,000",
+                        style = CoinkiriTheme.typography.labelMedium,
+                    )
+                }
+                Column() {
+                    Text(
+                        text = "24H 고가",
+                        color = Gray500,
+                        fontWeight = FontWeight.SemiBold,
+                        style = CoinkiriTheme.typography.labelMedium,
+                    )
+                    Text(
+                        text = "100,000,000",
+                        style = CoinkiriTheme.typography.labelMedium,
+                    )
+                }
+                Column() {
+                    Text(
+                        text = "24H 저가",
+                        color = Gray500,
+                        fontWeight = FontWeight.SemiBold,
+                        style = CoinkiriTheme.typography.labelMedium,
+                    )
+                    Text(
+                        text = "100,000,000",
+                        style = CoinkiriTheme.typography.labelMedium,
+                    )
+                }
+            }
+
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CoinDetailInfoItemPreview() {
+    CoinkiriTheme {
+        CoinDetailInfoItem()
+    }
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/coindetail/component/CoinTalkButton.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/coindetail/component/CoinTalkButton.kt
@@ -1,0 +1,75 @@
+package com.coinkiri.coinkiri.ui.coindetail.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.coinkiri.coinkiri.R
+import com.coinkiri.coinkiri.core.designsystem.theme.CoinkiriTheme
+import com.coinkiri.coinkiri.core.designsystem.theme.Gray600
+import com.coinkiri.coinkiri.core.designsystem.theme.White
+
+@Composable
+fun NavigateToCoinTalkButton() {
+    Row(
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .shadow(
+                elevation = 3.dp,
+                shape = RoundedCornerShape(10.dp)
+            )
+            .background(
+                color = White,
+                shape = RoundedCornerShape(10.dp)
+            )
+            .padding(vertical = 8.dp, horizontal = 12.dp)
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Image(
+                painter = painterResource(id = R.drawable.img_main_talk),
+                contentDescription = "",
+                modifier = Modifier.size(45.dp)
+            )
+            Spacer(modifier = Modifier.padding(3.dp))
+            Text(
+                text = "코인톡 참여하기",
+                fontWeight = FontWeight.SemiBold,
+                color = Gray600,
+                style = CoinkiriTheme.typography.titleMedium
+            )
+        }
+        Icon(
+            imageVector = Icons.Default.ChevronRight,
+            contentDescription = ""
+        )
+    }
+}
+
+@Preview
+@Composable
+fun NavigateToCoinTalkButtonPreview() {
+    CoinkiriTheme {
+        NavigateToCoinTalkButton()
+    }
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/main/MainScreen.kt
@@ -10,6 +10,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navOptions
 import com.coinkiri.coinkiri.ui.coin.CoinScreen
+import com.coinkiri.coinkiri.ui.coindetail.CoinDetailScreen
 import com.coinkiri.coinkiri.ui.home.HomeScreen
 import com.coinkiri.coinkiri.ui.login.LoginRoute
 import com.coinkiri.coinkiri.ui.profile.ProfileRoute
@@ -40,6 +41,7 @@ private fun MainScreenContent(
             splashScreen(navigator)
             homeScreen(navigator)
             coinScreen(navigator)
+            coinDetailScreen(navigator)
             talkScreen(navigator)
             profileScreen(navigator)
             loginRoute(navigator)
@@ -104,10 +106,18 @@ private fun NavGraphBuilder.loginRoute(navigator: ScreenNavigator) {
 private fun NavGraphBuilder.coinScreen(navigator: ScreenNavigator) {
     composable(Route.CoinScreen.routeName) {
         CoinScreen(
-            onBackClick = { navigator.popBackStack() }
+            onBackClick = { navigator.popBackStack() },
+            onCoinItemClick = { navigator.navigateToCoinDetail() }
         )
     }
 }
+
+private fun NavGraphBuilder.coinDetailScreen(navigator: ScreenNavigator) =
+    composable(Route.CoinDetailScreen.routeName) {
+        CoinDetailScreen(
+            onBackClick = { navigator.popBackStack() },
+        )
+    }
 
 private fun NavGraphBuilder.talkScreen(navigator: ScreenNavigator) {
     composable(Route.TalkScreen.routeName) {

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/main/ScreenNavigator.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/main/ScreenNavigator.kt
@@ -29,6 +29,9 @@ class ScreenNavigator(
         navController.navigate(Route.CoinScreen.routeName)
     }
 
+    fun navigateToCoinDetail() =
+        navController.navigate(Route.CoinDetailScreen.routeName)
+
     fun navigateTalk() {
         navController.navigate(Route.TalkScreen.routeName)
     }


### PR DESCRIPTION
## 관련 이슈번호

- Closes #9 

## 주요 변경사항

- 시세상세보기 화면 ui 구성

## 📸 Screensho
<img width="250" alt="스크린샷 2024-09-04 오후 2 29 41" src="https://github.com/user-attachments/assets/6a71e54d-b50e-4c85-955f-edeab90a91d1">

