### PR TITLE
홈 화면 유저 정보, 오늘의 코인정보 서버데이터 연결

### DIFF
--- a/app/src/main/java/com/coinkiri/coinkiri/data/coin/datasource/CoinDataSource.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/data/coin/datasource/CoinDataSource.kt
@@ -1,6 +1,7 @@
 package com.coinkiri.coinkiri.data.coin.datasource
 
 import com.coinkiri.coinkiri.core.network.BaseResponse
+import com.coinkiri.coinkiri.data.coin.dto.response.CoinCountResponseDto
 import com.coinkiri.coinkiri.data.coin.dto.response.CoinDetailResponseDto
 import com.coinkiri.coinkiri.data.coin.dto.response.CoinResponseDto
 
@@ -9,5 +10,7 @@ interface CoinDataSource {
     suspend fun getCoinList(): BaseResponse<List<CoinResponseDto>>
 
     suspend fun getCoinDetail(market: String): BaseResponse<CoinDetailResponseDto>
+
+    suspend fun getCoinRiseAndFallCount(): BaseResponse<CoinCountResponseDto>
 
 }

--- a/app/src/main/java/com/coinkiri/coinkiri/data/coin/datasourceimpl/CoinDataSourceImpl.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/data/coin/datasourceimpl/CoinDataSourceImpl.kt
@@ -2,6 +2,7 @@ package com.coinkiri.coinkiri.data.coin.datasourceimpl
 
 import com.coinkiri.coinkiri.core.network.BaseResponse
 import com.coinkiri.coinkiri.data.coin.datasource.CoinDataSource
+import com.coinkiri.coinkiri.data.coin.dto.response.CoinCountResponseDto
 import com.coinkiri.coinkiri.data.coin.dto.response.CoinDetailResponseDto
 import com.coinkiri.coinkiri.data.coin.dto.response.CoinResponseDto
 import com.coinkiri.coinkiri.data.coin.service.CoinService
@@ -16,4 +17,7 @@ class CoinDataSourceImpl @Inject constructor(
 
     override suspend fun getCoinDetail(market: String): BaseResponse<CoinDetailResponseDto> =
         coinService.getCoinDetailInfo(market)
+
+    override suspend fun getCoinRiseAndFallCount(): BaseResponse<CoinCountResponseDto> =
+        coinService.getCoinRiseAndFallCount()
 }

--- a/app/src/main/java/com/coinkiri/coinkiri/data/coin/dto/response/CoinCountResponseDto.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/data/coin/dto/response/CoinCountResponseDto.kt
@@ -1,0 +1,12 @@
+package com.coinkiri.coinkiri.data.coin.dto.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CoinCountResponseDto(
+    @SerialName("riseCount")
+    val riseCount: Int,
+    @SerialName("fallCount")
+    val fallCount: Int
+)

--- a/app/src/main/java/com/coinkiri/coinkiri/data/coin/mapper/CoinCountMapper.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/data/coin/mapper/CoinCountMapper.kt
@@ -1,0 +1,10 @@
+package com.coinkiri.coinkiri.data.coin.mapper
+
+import com.coinkiri.coinkiri.data.coin.dto.response.CoinCountResponseDto
+import com.coinkiri.coinkiri.domain.coin.entity.response.CoinCountResponseEntity
+
+fun CoinCountResponseDto.toCoinCountResponseEntity(): CoinCountResponseEntity =
+    CoinCountResponseEntity(
+        riseCount = riseCount,
+        fallCount = fallCount
+    )

--- a/app/src/main/java/com/coinkiri/coinkiri/data/coin/repositoryimpl/CoinRepositoryImpl.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/data/coin/repositoryimpl/CoinRepositoryImpl.kt
@@ -1,8 +1,10 @@
 package com.coinkiri.coinkiri.data.coin.repositoryimpl
 
 import com.coinkiri.coinkiri.data.coin.datasource.CoinDataSource
+import com.coinkiri.coinkiri.data.coin.mapper.toCoinCountResponseEntity
 import com.coinkiri.coinkiri.data.coin.mapper.toCoinDetailResponseEntity
 import com.coinkiri.coinkiri.data.coin.mapper.toCoinEntity
+import com.coinkiri.coinkiri.domain.coin.entity.response.CoinCountResponseEntity
 import com.coinkiri.coinkiri.domain.coin.entity.response.CoinDetailResponseEntity
 import com.coinkiri.coinkiri.domain.coin.entity.response.CoinResponseEntity
 import com.coinkiri.coinkiri.domain.coin.repository.CoinRepository
@@ -12,17 +14,18 @@ class CoinRepositoryImpl @Inject constructor(
     private val coinDataSource: CoinDataSource
 ) : CoinRepository {
 
-    override suspend fun getCoinList(): Result<List<CoinResponseEntity>> = runCatching {
-        val response = coinDataSource.getCoinList()
+    override suspend fun getCoinList(): Result<List<CoinResponseEntity>> =
+        runCatching {
+            val response = coinDataSource.getCoinList()
 
-        if (response.code == SUCCESS_CODE) {
-            response.data.map { coinResponseDto ->
-                coinResponseDto.toCoinEntity()
+            if (response.code == SUCCESS_CODE) {
+                response.data.map { coinResponseDto ->
+                    coinResponseDto.toCoinEntity()
+                }
+            } else {
+                throw Exception("Failed to fetch coin list: ${response.message}")
             }
-        } else {
-            throw Exception("Failed to fetch coin list: ${response.message}")
         }
-    }
 
     override suspend fun getCoinDetail(market: String): Result<CoinDetailResponseEntity> =
         runCatching {
@@ -32,6 +35,17 @@ class CoinRepositoryImpl @Inject constructor(
                 response.data.toCoinDetailResponseEntity()
             } else {
                 throw Exception("Failed to fetch coin detail: ${response.message}")
+            }
+        }
+
+    override suspend fun getCoinRiseAndFallCount(): Result<CoinCountResponseEntity> =
+        runCatching {
+            val response = coinDataSource.getCoinRiseAndFallCount()
+
+            if (response.code == SUCCESS_CODE) {
+                response.data.toCoinCountResponseEntity()
+            } else {
+                throw Exception("Failed to fetch coin count: ${response.message}")
             }
         }
 

--- a/app/src/main/java/com/coinkiri/coinkiri/data/coin/service/CoinService.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/data/coin/service/CoinService.kt
@@ -1,6 +1,7 @@
 package com.coinkiri.coinkiri.data.coin.service
 
 import com.coinkiri.coinkiri.core.network.BaseResponse
+import com.coinkiri.coinkiri.data.coin.dto.response.CoinCountResponseDto
 import com.coinkiri.coinkiri.data.coin.dto.response.CoinDetailResponseDto
 import com.coinkiri.coinkiri.data.coin.dto.response.CoinResponseDto
 import retrofit2.http.GET
@@ -14,4 +15,7 @@ interface CoinService {
     suspend fun getCoinDetailInfo(
         @Query("market") market: String
     ): BaseResponse<CoinDetailResponseDto>
+
+    @GET("/api/v1/coin/count/rise-fall")
+    suspend fun getCoinRiseAndFallCount(): BaseResponse<CoinCountResponseDto>
 }

--- a/app/src/main/java/com/coinkiri/coinkiri/data/user/datasourceimpl/UserDataSourceImpl.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/data/user/datasourceimpl/UserDataSourceImpl.kt
@@ -10,7 +10,7 @@ class UserDataSourceImpl @Inject constructor(
     private val userService: UserService
 ) : UserDataSource {
 
-    override suspend fun getUser(): BaseResponse<UserResponseDto> {
-        return userService.getUser()
-    }
+    override suspend fun getUser(): BaseResponse<UserResponseDto> =
+        userService.getUser()
+
 }

--- a/app/src/main/java/com/coinkiri/coinkiri/data/user/mapper/UserMapper.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/data/user/mapper/UserMapper.kt
@@ -1,10 +1,10 @@
 package com.coinkiri.coinkiri.data.user.mapper
 
 import com.coinkiri.coinkiri.data.user.dto.UserResponseDto
-import com.coinkiri.coinkiri.domain.user.entity.UserEntity
+import com.coinkiri.coinkiri.domain.user.entity.UserResponseEntity
 
-fun UserResponseDto.toUserEntity(): UserEntity =
-    UserEntity(
+fun UserResponseDto.toUserResponseEntity(): UserResponseEntity =
+    UserResponseEntity(
         nickname = nickname,
         pic = pic
     )

--- a/app/src/main/java/com/coinkiri/coinkiri/data/user/repositoryimpl/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/data/user/repositoryimpl/UserRepositoryImpl.kt
@@ -1,23 +1,25 @@
 package com.coinkiri.coinkiri.data.user.repositoryimpl
 
 import com.coinkiri.coinkiri.data.user.datasource.UserDataSource
-import com.coinkiri.coinkiri.data.user.mapper.toUserEntity
-import com.coinkiri.coinkiri.domain.user.entity.UserEntity
+import com.coinkiri.coinkiri.data.user.mapper.toUserResponseEntity
+import com.coinkiri.coinkiri.domain.user.entity.UserResponseEntity
 import com.coinkiri.coinkiri.domain.user.repository.UserRepository
 import jakarta.inject.Inject
 
 class UserRepositoryImpl @Inject constructor(
     private val userDataSource: UserDataSource
 ) : UserRepository {
-    override suspend fun getUserDetail(): Result<UserEntity> = runCatching {
-        val result = userDataSource.getUser()
 
-        if (result.code == SUCCESS_CODE) {
-            result.data.toUserEntity()
-        } else {
-            throw Exception("Failed to fetch userInfo: ${result.message}")
+    override suspend fun getUser(): Result<UserResponseEntity> =
+        runCatching {
+            val result = userDataSource.getUser()
+
+            if (result.code == SUCCESS_CODE) {
+                result.data.toUserResponseEntity()
+            } else {
+                throw Exception("Failed to fetch userInfo: ${result.message}")
+            }
         }
-    }
 
     companion object {
         private const val SUCCESS_CODE = "O001"

--- a/app/src/main/java/com/coinkiri/coinkiri/domain/coin/entity/response/CoinCountResponseEntity.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/domain/coin/entity/response/CoinCountResponseEntity.kt
@@ -1,0 +1,7 @@
+package com.coinkiri.coinkiri.domain.coin.entity.response
+
+data class CoinCountResponseEntity(
+    val riseCount: Int,
+    val fallCount: Int,
+)
+

--- a/app/src/main/java/com/coinkiri/coinkiri/domain/coin/repository/CoinRepository.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/domain/coin/repository/CoinRepository.kt
@@ -1,5 +1,6 @@
 package com.coinkiri.coinkiri.domain.coin.repository
 
+import com.coinkiri.coinkiri.domain.coin.entity.response.CoinCountResponseEntity
 import com.coinkiri.coinkiri.domain.coin.entity.response.CoinDetailResponseEntity
 import com.coinkiri.coinkiri.domain.coin.entity.response.CoinResponseEntity
 
@@ -8,5 +9,7 @@ interface CoinRepository {
     suspend fun getCoinList(): Result<List<CoinResponseEntity>>
 
     suspend fun getCoinDetail(market: String): Result<CoinDetailResponseEntity>
+
+    suspend fun getCoinRiseAndFallCount(): Result<CoinCountResponseEntity>
 
 }

--- a/app/src/main/java/com/coinkiri/coinkiri/domain/coin/usecase/GetCoinRiseAndFallCountUseCase.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/domain/coin/usecase/GetCoinRiseAndFallCountUseCase.kt
@@ -1,0 +1,12 @@
+package com.coinkiri.coinkiri.domain.coin.usecase
+
+import com.coinkiri.coinkiri.domain.coin.entity.response.CoinCountResponseEntity
+import com.coinkiri.coinkiri.domain.coin.repository.CoinRepository
+import javax.inject.Inject
+
+class GetCoinRiseAndFallCountUseCase @Inject constructor(
+    private val coinRepository: CoinRepository
+) {
+    suspend operator fun invoke(): Result<CoinCountResponseEntity> =
+        coinRepository.getCoinRiseAndFallCount()
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/domain/user/entity/UserResponseEntity.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/domain/user/entity/UserResponseEntity.kt
@@ -1,6 +1,6 @@
 package com.coinkiri.coinkiri.domain.user.entity
 
-data class UserEntity(
+data class UserResponseEntity(
     val nickname: String,
     val pic: String
 )

--- a/app/src/main/java/com/coinkiri/coinkiri/domain/user/repository/UserRepository.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/domain/user/repository/UserRepository.kt
@@ -1,7 +1,7 @@
 package com.coinkiri.coinkiri.domain.user.repository
 
-import com.coinkiri.coinkiri.domain.user.entity.UserEntity
+import com.coinkiri.coinkiri.domain.user.entity.UserResponseEntity
 
 interface UserRepository {
-    suspend fun getUserDetail(): Result<UserEntity>
+    suspend fun getUser(): Result<UserResponseEntity>
 }

--- a/app/src/main/java/com/coinkiri/coinkiri/domain/user/usecase/GetUserInfoUseCase.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/domain/user/usecase/GetUserInfoUseCase.kt
@@ -1,12 +1,12 @@
 package com.coinkiri.coinkiri.domain.user.usecase
 
-import com.coinkiri.coinkiri.domain.user.entity.UserEntity
+import com.coinkiri.coinkiri.domain.user.entity.UserResponseEntity
 import com.coinkiri.coinkiri.domain.user.repository.UserRepository
 import jakarta.inject.Inject
 
 class GetUserInfoUseCase @Inject constructor(
     private val userRepository: UserRepository
 ) {
-    suspend operator fun invoke(): Result<UserEntity> =
-        userRepository.getUserDetail()
+    suspend operator fun invoke(): Result<UserResponseEntity> =
+        userRepository.getUser()
 }

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/home/HomeScreen.kt
@@ -55,6 +55,7 @@ fun HomeScreen(
     val viewModel: HomeViewModel = hiltViewModel()
 
     LaunchedEffect(Unit) {
+        viewModel.fetchUserInfo()
         viewModel.fetchCoinRiseAndFallCount()
     }
 
@@ -136,6 +137,7 @@ private fun InfoSection(
 ) {
 
     val coinCount by viewModel.coinRiseAndFallCount.collectAsStateWithLifecycle()
+    val userInfo by viewModel.userInfo.collectAsStateWithLifecycle()
 
     Column(
         modifier = Modifier
@@ -143,7 +145,7 @@ private fun InfoSection(
             .fillMaxWidth()
     ) {
         Text(
-            text = "안녕하세요, 김영재님",
+            text = "안녕하세요, ${userInfo.nickname}님",
             color = White,
             fontWeight = FontWeight.Bold,
             style = CoinkiriTheme.typography.titleLarge,

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/home/HomeScreen.kt
@@ -21,14 +21,24 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.coinkiri.coinkiri.R
+import com.coinkiri.coinkiri.core.designsystem.theme.Blue
 import com.coinkiri.coinkiri.core.designsystem.theme.CoinkiriTheme
+import com.coinkiri.coinkiri.core.designsystem.theme.Red
 import com.coinkiri.coinkiri.core.designsystem.theme.SemiBlue
 import com.coinkiri.coinkiri.core.designsystem.theme.White
 import com.coinkiri.coinkiri.ui.home.component.CoinTalkMenuCard
@@ -41,6 +51,13 @@ fun HomeScreen(
     navigateToTalkList: () -> Unit,
     navigateToBook: () -> Unit,
 ) {
+
+    val viewModel: HomeViewModel = hiltViewModel()
+
+    LaunchedEffect(Unit) {
+        viewModel.fetchCoinRiseAndFallCount()
+    }
+
     Scaffold(
         topBar = {
             HomeTopBar(
@@ -52,7 +69,8 @@ fun HomeScreen(
                 innerPadding,
                 onTalkClick = navigateToTalkList,
                 onPriceClick = navigateToCoinList,
-                onBookClick = navigateToBook
+                onBookClick = navigateToBook,
+                viewModel = viewModel
             )
         }
     )
@@ -94,7 +112,8 @@ private fun HomeScreenContent(
     padding: PaddingValues,
     onTalkClick: () -> Unit,
     onBookClick: () -> Unit,
-    onPriceClick: () -> Unit
+    onPriceClick: () -> Unit,
+    viewModel: HomeViewModel
 ) {
     Column(
         modifier = Modifier
@@ -102,7 +121,7 @@ private fun HomeScreenContent(
             .fillMaxSize()
             .background(SemiBlue)
     ) {
-        InfoSection()
+        InfoSection(viewModel)
         MenuSection(
             onTalkClick = onTalkClick,
             onBookClick = onBookClick,
@@ -113,8 +132,11 @@ private fun HomeScreenContent(
 
 @Composable
 private fun InfoSection(
-    /*TODO text값 실 데이터 받아서 연결*/
+    viewModel: HomeViewModel
 ) {
+
+    val coinCount by viewModel.coinRiseAndFallCount.collectAsStateWithLifecycle()
+
     Column(
         modifier = Modifier
             .padding(vertical = 20.dp, horizontal = 30.dp)
@@ -128,13 +150,35 @@ private fun InfoSection(
             modifier = Modifier.padding(bottom = 8.dp)
         )
         Text(
-            text = "오늘은 00개의 코인이 상승중이네요!",
+            text = buildAnnotatedString {
+                append("오늘은 ")
+                withStyle(
+                    style = SpanStyle(
+                        color = Red,
+                        fontSize = 20.sp
+                    )
+                ) {
+                    append("${coinCount.riseCount}")
+                }
+                append("개의 코인이 상승중이네요!")
+            },
             color = White,
             fontWeight = FontWeight.SemiBold,
             style = CoinkiriTheme.typography.titleMedium
         )
         Text(
-            text = "하락중인 코인은 000개에요!",
+            text = buildAnnotatedString {
+                append("하락중인 코인은 ")
+                withStyle(
+                    style = SpanStyle(
+                        color = Blue,
+                        fontSize = 20.sp
+                    )
+                ) {
+                    append("${coinCount.fallCount}")
+                }
+                append("개에요!")
+            },
             color = White,
             fontWeight = FontWeight.SemiBold,
             style = CoinkiriTheme.typography.titleMedium,

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/home/HomeViewModel.kt
@@ -1,0 +1,38 @@
+package com.coinkiri.coinkiri.ui.home
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.coinkiri.coinkiri.domain.coin.usecase.GetCoinRiseAndFallCountUseCase
+import com.coinkiri.coinkiri.ui.home.model.CoinCountModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class HomeViewModel @Inject constructor(
+    private val getCoinRiseAndFallCountUseCase: GetCoinRiseAndFallCountUseCase
+) : ViewModel() {
+
+    private val _coinRiseAndFallCount = MutableStateFlow(CoinCountModel())
+    val coinRiseAndFallCount: StateFlow<CoinCountModel>
+        get() = _coinRiseAndFallCount
+
+    suspend fun fetchCoinRiseAndFallCount() {
+        viewModelScope.launch {
+            val result = getCoinRiseAndFallCountUseCase()
+
+            result
+                .onSuccess { coinCountResponseEntity ->
+                    _coinRiseAndFallCount.value = CoinCountModel(
+                        riseCount = coinCountResponseEntity.riseCount,
+                        fallCount = coinCountResponseEntity.fallCount
+                    )
+                }
+                .onFailure { exception ->
+                    "${exception.message}"
+                }
+        }
+    }
+}

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/home/HomeViewModel.kt
@@ -3,7 +3,10 @@ package com.coinkiri.coinkiri.ui.home
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.coinkiri.coinkiri.domain.coin.usecase.GetCoinRiseAndFallCountUseCase
+import com.coinkiri.coinkiri.domain.user.entity.UserResponseEntity
+import com.coinkiri.coinkiri.domain.user.usecase.GetUserInfoUseCase
 import com.coinkiri.coinkiri.ui.home.model.CoinCountModel
+import com.coinkiri.coinkiri.ui.profile.model.UserInfoModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -12,12 +15,17 @@ import javax.inject.Inject
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
-    private val getCoinRiseAndFallCountUseCase: GetCoinRiseAndFallCountUseCase
+    private val getCoinRiseAndFallCountUseCase: GetCoinRiseAndFallCountUseCase,
+    private val getUserInfoUseCase: GetUserInfoUseCase
 ) : ViewModel() {
 
     private val _coinRiseAndFallCount = MutableStateFlow(CoinCountModel())
     val coinRiseAndFallCount: StateFlow<CoinCountModel>
         get() = _coinRiseAndFallCount
+
+    private val _userInfo = MutableStateFlow(UserInfoModel())
+    val userInfo: StateFlow<UserInfoModel>
+        get() = _userInfo
 
     suspend fun fetchCoinRiseAndFallCount() {
         viewModelScope.launch {
@@ -34,5 +42,25 @@ class HomeViewModel @Inject constructor(
                     "${exception.message}"
                 }
         }
+    }
+
+    suspend fun fetchUserInfo() =
+        viewModelScope.launch {
+            val result = getUserInfoUseCase()
+
+            result
+                .onSuccess { userResponseEntity ->
+                    handleFetchUserInfoSuccess(userResponseEntity)
+                }
+                .onFailure { exception ->
+                    "${exception.message}"
+                }
+        }
+
+    private fun handleFetchUserInfoSuccess(userResponseEntity: UserResponseEntity) {
+        _userInfo.value = UserInfoModel(
+            nickname = userResponseEntity.nickname,
+            pic = userResponseEntity.pic
+        )
     }
 }

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/home/model/CoinCountModel.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/home/model/CoinCountModel.kt
@@ -1,0 +1,6 @@
+package com.coinkiri.coinkiri.ui.home.model
+
+data class CoinCountModel(
+    val riseCount: Int = 0,
+    val fallCount: Int = 0,
+)

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/main/MainScreen.kt
@@ -13,8 +13,6 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navOptions
 import com.coinkiri.coinkiri.core.navigation.Route
-import com.coinkiri.coinkiri.ui.coin.coinlist.CoinListScreen
-import com.coinkiri.coinkiri.ui.coin.coindetail.CoinDetailScreen
 import com.coinkiri.coinkiri.ui.coin.navigation.coinGraph
 import com.coinkiri.coinkiri.ui.home.navigation.homeNavGraph
 import com.coinkiri.coinkiri.ui.login.navigation.loginGraph

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/profile/ProfileScreen.kt
@@ -27,7 +27,6 @@ import com.coinkiri.coinkiri.core.designsystem.component.dialog.ConfirmationDial
 import com.coinkiri.coinkiri.core.designsystem.component.topappbar.CoinkiriTopBar
 import com.coinkiri.coinkiri.core.designsystem.theme.CoinkiriTheme
 import com.coinkiri.coinkiri.core.designsystem.theme.White
-import com.coinkiri.coinkiri.domain.user.entity.UserResponseEntity
 import com.coinkiri.coinkiri.ui.profile.component.OptionItem
 import com.coinkiri.coinkiri.ui.profile.component.SettingOptionsItem
 import com.coinkiri.coinkiri.ui.profile.component.UserInfoItem

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/profile/ProfileScreen.kt
@@ -27,10 +27,11 @@ import com.coinkiri.coinkiri.core.designsystem.component.dialog.ConfirmationDial
 import com.coinkiri.coinkiri.core.designsystem.component.topappbar.CoinkiriTopBar
 import com.coinkiri.coinkiri.core.designsystem.theme.CoinkiriTheme
 import com.coinkiri.coinkiri.core.designsystem.theme.White
-import com.coinkiri.coinkiri.domain.user.entity.UserEntity
+import com.coinkiri.coinkiri.domain.user.entity.UserResponseEntity
 import com.coinkiri.coinkiri.ui.profile.component.OptionItem
 import com.coinkiri.coinkiri.ui.profile.component.SettingOptionsItem
 import com.coinkiri.coinkiri.ui.profile.component.UserInfoItem
+import com.coinkiri.coinkiri.ui.profile.model.UserInfoModel
 import kotlinx.coroutines.flow.collectLatest
 
 @Composable
@@ -46,7 +47,7 @@ fun ProfileRoute(
         viewModel.profileSideEffects
             .flowWithLifecycle(lifecycleOwner.lifecycle)
             .collectLatest { sideEffect ->
-                when(sideEffect) {
+                when (sideEffect) {
                     is ProfileSideEffect.LogoutSuccess -> {
                         navigateToLogin()
                     }
@@ -89,7 +90,7 @@ fun ProfileRoute(
 private fun ProfileScreen(
     onBackClick: () -> Unit,
     onLogOutClick: () -> Unit,
-    userInfo: UserEntity?
+    userInfo: UserInfoModel
 ) {
 
     Scaffold(
@@ -123,7 +124,7 @@ private fun ProfileTopBar(
 private fun ProfileContent(
     padding: PaddingValues,
     onLogOutClick: () -> Unit,
-    userInfo: UserEntity?
+    userInfo: UserInfoModel
 ) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -137,17 +138,14 @@ private fun ProfileContent(
             verticalArrangement = Arrangement.spacedBy(8.dp),
             modifier = Modifier.padding(10.dp),
         ) {
-            SettingOptionsItem(
-                title = "App 설정"
-            ) {
+            SettingOptionsItem(title = "App 설정") {
                 OptionItem(
                     text = "테마설정",
                     onOptionClick = { /*TODO*/ }
                 )
             }
-            SettingOptionsItem(
-                title = "고객지원"
-            ) {
+
+            SettingOptionsItem(title = "고객지원") {
                 OptionItem(
                     text = "정보수정",
                     onOptionClick = { /*TODO*/ }
@@ -161,9 +159,8 @@ private fun ProfileContent(
                     onOptionClick = { /*TODO*/ }
                 )
             }
-            SettingOptionsItem(
-                title = "기타"
-            ) {
+
+            SettingOptionsItem(title = "기타") {
                 OptionItem(
                     text = "약관 및 개인정보 취급방침",
                     onOptionClick = { /*TODO*/ }
@@ -180,10 +177,7 @@ private fun ProfileScreenPreview() {
         ProfileScreen(
             onBackClick = {},
             onLogOutClick = {},
-            userInfo = UserEntity(
-                pic = "",
-                nickname = ""
-            )
+            userInfo = UserInfoModel()
         )
     }
 }

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/profile/ProfileViewModel.kt
@@ -3,16 +3,15 @@ package com.coinkiri.coinkiri.ui.profile
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.coinkiri.coinkiri.domain.token.repository.TokenRepository
-import com.coinkiri.coinkiri.domain.user.entity.UserEntity
-import com.coinkiri.coinkiri.domain.user.repository.UserRepository
+import com.coinkiri.coinkiri.domain.user.entity.UserResponseEntity
 import com.coinkiri.coinkiri.domain.user.usecase.GetUserInfoUseCase
+import com.coinkiri.coinkiri.ui.profile.model.UserInfoModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -25,8 +24,8 @@ class ProfileViewModel @Inject constructor(
     val profileSideEffects: SharedFlow<ProfileSideEffect>
         get() = _profileSideEffects
 
-    private val _userInfo = MutableStateFlow<UserEntity?>(null)
-    val userInfo: StateFlow<UserEntity?>
+    private val _userInfo = MutableStateFlow(UserInfoModel())
+    val userInfo: StateFlow<UserInfoModel>
         get() = _userInfo
 
     fun logout() {
@@ -54,17 +53,23 @@ class ProfileViewModel @Inject constructor(
         )
     }
 
-    fun fetchUserInfo() {
+    fun fetchUserInfo() =
         viewModelScope.launch {
             val result = getUserInfoUseCase()
 
             result
-                .onSuccess { userInfo ->
-                    _userInfo.value = userInfo
+                .onSuccess { userResponseEntity ->
+                    handleFetchUserInfoSuccess(userResponseEntity)
                 }
                 .onFailure { exception ->
                     "${exception.message}"
                 }
         }
+
+    private fun handleFetchUserInfoSuccess(userResponseEntity: UserResponseEntity) {
+        _userInfo.value = UserInfoModel(
+            nickname = userResponseEntity.nickname,
+            pic = userResponseEntity.pic
+        )
     }
 }

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/profile/component/EditItem.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/profile/component/EditItem.kt
@@ -1,4 +1,4 @@
-package com.coinkiri.coinkiri.ui.profilemodify.component
+package com.coinkiri.coinkiri.ui.profile.component
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
@@ -6,7 +6,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -40,12 +39,10 @@ import com.coinkiri.coinkiri.R
 import com.coinkiri.coinkiri.core.designsystem.theme.Black
 import com.coinkiri.coinkiri.core.designsystem.theme.Gray300
 import com.coinkiri.coinkiri.core.designsystem.theme.White
-import com.coinkiri.coinkiri.domain.user.entity.UserResponseEntity
 import com.coinkiri.coinkiri.ui.profile.model.UserInfoModel
 
 @Composable
-fun ProfileModifyItem(
-    padding: PaddingValues,
+fun EditItem(
     userInfo: UserInfoModel,
 ) {
 
@@ -55,7 +52,6 @@ fun ProfileModifyItem(
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier
-            .padding(padding)
             .padding(30.dp)
     ) {
         Box(
@@ -109,31 +105,28 @@ fun ProfileModifyItem(
                 modifier = Modifier
                     .weight(0.4f)
             )
-            if (text != null) {
-                TextField(
-                    value = text!!,
-                    onValueChange = { newText ->
-                        text = newText
-                    },
-                    colors = TextFieldDefaults.colors(
-                        unfocusedIndicatorColor = Color.LightGray,
-                        focusedIndicatorColor = Black,
-                        unfocusedContainerColor = White,
-                        focusedContainerColor = White
-                    ),
-                    modifier = Modifier
-                        .weight(1f)
-                )
-            }
+            TextField(
+                value = text,
+                onValueChange = { newText ->
+                    text = newText
+                },
+                colors = TextFieldDefaults.colors(
+                    unfocusedIndicatorColor = Color.LightGray,
+                    focusedIndicatorColor = Black,
+                    unfocusedContainerColor = White,
+                    focusedContainerColor = White
+                ),
+                modifier = Modifier
+                    .weight(1f)
+            )
         }
     }
 }
 
 @Preview
 @Composable
-fun ProfileModifyItemPreview() {
-    ProfileModifyItem(
-        padding = PaddingValues(),
+fun EditItemPreview() {
+    EditItem(
         userInfo = UserInfoModel()
     )
 }

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/profile/component/UserInfoItem.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/profile/component/UserInfoItem.kt
@@ -1,7 +1,8 @@
 package com.coinkiri.coinkiri.ui.profile.component
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -9,8 +10,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -22,12 +21,11 @@ import com.coinkiri.coinkiri.R
 import com.coinkiri.coinkiri.core.designsystem.theme.CoinkiriTheme
 import com.coinkiri.coinkiri.core.designsystem.theme.Gray300
 import com.coinkiri.coinkiri.core.designsystem.theme.White
-import com.coinkiri.coinkiri.core.util.byteArrayToPainter
-import com.coinkiri.coinkiri.domain.user.entity.UserEntity
+import com.coinkiri.coinkiri.ui.profile.model.UserInfoModel
 
 @Composable
 fun UserInfoItem(
-    userInfo: UserEntity?
+    userInfo: UserInfoModel
 ) {
     Column(
         verticalArrangement = Arrangement.Center,
@@ -36,30 +34,27 @@ fun UserInfoItem(
             .fillMaxWidth()
             .padding(15.dp)
     ) {
-
-        Card(
-            shape = RoundedCornerShape(50.dp),
-            colors = CardDefaults.cardColors(White),
-            border = BorderStroke(
-                color = Gray300,
-                width = 1.dp
-            ),
-            modifier = Modifier.size(150.dp)
-        ) {
-            if (userInfo != null) {
-                Image(
-                    painter = byteArrayToPainter(userInfo.pic),
-                    contentDescription = "default img"
+        Image(
+//                painter = byteArrayToPainter(userInfo.pic),
+            painter = painterResource(id = R.drawable.img_coinkiri_app_icon_dark),
+            contentDescription = "default img",
+            modifier = Modifier
+                .size(150.dp)
+                .background(
+                    color = White,
+                    shape = RoundedCornerShape(50.dp)
                 )
-            }
-        }
+                .border(
+                    width = 1.dp,
+                    color = Gray300,
+                    shape = RoundedCornerShape(50.dp)
+                )
+        )
         Spacer(modifier = Modifier.padding(12.dp))
-        if (userInfo != null) {
-            Text(
-                text = userInfo.nickname,
-                style = CoinkiriTheme.typography.headlineSmall
-            )
-        }
+        Text(
+            text = userInfo.nickname,
+            style = CoinkiriTheme.typography.headlineSmall
+        )
     }
 }
 
@@ -68,9 +63,8 @@ fun UserInfoItem(
 private fun UserInfoItemPreview() {
     CoinkiriTheme {
         UserInfoItem(
-            UserEntity(
-                pic = "",
-                nickname = ""
+            UserInfoModel(
+                nickname = "userName"
             )
         )
     }

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/profile/model/UserInfoModel.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/profile/model/UserInfoModel.kt
@@ -1,0 +1,6 @@
+package com.coinkiri.coinkiri.ui.profile.model
+
+data class UserInfoModel(
+    val nickname: String = "",
+    val pic: String = ""
+)

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/profile/profileedit/ProfileEditScreen.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/profile/profileedit/ProfileEditScreen.kt
@@ -1,27 +1,27 @@
-package com.coinkiri.coinkiri.ui.profilemodify
+package com.coinkiri.coinkiri.ui.profile.profileedit
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.coinkiri.coinkiri.core.designsystem.component.topappbar.CoinkiriTopBar
 import com.coinkiri.coinkiri.core.designsystem.theme.White
-import com.coinkiri.coinkiri.domain.user.entity.UserResponseEntity
 import com.coinkiri.coinkiri.ui.profile.model.UserInfoModel
-import com.coinkiri.coinkiri.ui.profilemodify.component.ProfileModifyItem
+import com.coinkiri.coinkiri.ui.profile.component.EditItem
 
 @Composable
-fun ProfileModifyScreen(
+fun ProfileEditScreen(
     userInfo: UserInfoModel,
     onCloseClick: () -> Unit
 ) {
     Scaffold(
         topBar = {
-            ProfileModifyTopBar(
+            ProfileEditTopBar(
                 onCloseClick = onCloseClick,
                 onCompleteClick = {
                     // 완료 버튼
@@ -29,7 +29,7 @@ fun ProfileModifyScreen(
             )
         },
         content = { padding ->
-            ProfileModifyContent(
+            ProfileEditContent(
                 padding = padding,
                 userInfo = userInfo
             )
@@ -38,7 +38,7 @@ fun ProfileModifyScreen(
 }
 
 @Composable
-private fun ProfileModifyTopBar(
+private fun ProfileEditTopBar(
     onCloseClick: () -> Unit,
     onCompleteClick: () -> Unit
 ) {
@@ -52,17 +52,17 @@ private fun ProfileModifyTopBar(
 }
 
 @Composable
-private fun ProfileModifyContent(
+private fun ProfileEditContent(
     padding: PaddingValues,
     userInfo: UserInfoModel,
 ) {
     Column(
         modifier = Modifier
+            .padding(padding)
             .fillMaxSize()
             .background(White)
     ) {
-        ProfileModifyItem(
-            padding = padding,
+        EditItem(
             userInfo = userInfo
         )
     }
@@ -70,8 +70,8 @@ private fun ProfileModifyContent(
 
 @Preview
 @Composable
-fun ProfileModifyScreenPreview() {
-    ProfileModifyScreen(
+fun ProfileEditScreenPreview() {
+    ProfileEditScreen(
         onCloseClick = {},
         userInfo = UserInfoModel()
     )

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/profilemodify/ProfileModifyScreen.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/profilemodify/ProfileModifyScreen.kt
@@ -10,12 +10,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.coinkiri.coinkiri.core.designsystem.component.topappbar.CoinkiriTopBar
 import com.coinkiri.coinkiri.core.designsystem.theme.White
-import com.coinkiri.coinkiri.domain.user.entity.UserEntity
+import com.coinkiri.coinkiri.domain.user.entity.UserResponseEntity
+import com.coinkiri.coinkiri.ui.profile.model.UserInfoModel
 import com.coinkiri.coinkiri.ui.profilemodify.component.ProfileModifyItem
 
 @Composable
 fun ProfileModifyScreen(
-    userInfo: UserEntity?,
+    userInfo: UserInfoModel,
     onCloseClick: () -> Unit
 ) {
     Scaffold(
@@ -53,7 +54,7 @@ private fun ProfileModifyTopBar(
 @Composable
 private fun ProfileModifyContent(
     padding: PaddingValues,
-    userInfo: UserEntity?
+    userInfo: UserInfoModel,
 ) {
     Column(
         modifier = Modifier
@@ -72,9 +73,6 @@ private fun ProfileModifyContent(
 fun ProfileModifyScreenPreview() {
     ProfileModifyScreen(
         onCloseClick = {},
-        userInfo = UserEntity(
-            pic = "",
-            nickname = ""
-        )
+        userInfo = UserInfoModel()
     )
 }

--- a/app/src/main/java/com/coinkiri/coinkiri/ui/profilemodify/component/ProfileModifyItem.kt
+++ b/app/src/main/java/com/coinkiri/coinkiri/ui/profilemodify/component/ProfileModifyItem.kt
@@ -40,16 +40,17 @@ import com.coinkiri.coinkiri.R
 import com.coinkiri.coinkiri.core.designsystem.theme.Black
 import com.coinkiri.coinkiri.core.designsystem.theme.Gray300
 import com.coinkiri.coinkiri.core.designsystem.theme.White
-import com.coinkiri.coinkiri.domain.user.entity.UserEntity
+import com.coinkiri.coinkiri.domain.user.entity.UserResponseEntity
+import com.coinkiri.coinkiri.ui.profile.model.UserInfoModel
 
 @Composable
 fun ProfileModifyItem(
     padding: PaddingValues,
-    userInfo: UserEntity?
+    userInfo: UserInfoModel,
 ) {
 
     var text by remember {
-        mutableStateOf(userInfo?.nickname)
+        mutableStateOf(userInfo.nickname)
     }
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -133,9 +134,6 @@ fun ProfileModifyItem(
 fun ProfileModifyItemPreview() {
     ProfileModifyItem(
         padding = PaddingValues(),
-        userInfo = UserEntity(
-            nickname = "",
-            pic = ""
-        )
+        userInfo = UserInfoModel()
     )
 }


### PR DESCRIPTION
## 관련 이슈번호

- Closes #45 

## 주요 변경사항

- profile 패키지 경로 수정
- profilemodify -> profileedit 하위 패키지로 변경
- 오늘의 상승하락 코인정보 데이터 수신
- 홈 화면 유저정보 데이터 연결

## 📸 Screenshot (optional)
<img src="https://github.com/user-attachments/assets/9605a95f-49fc-4ed5-9c5f-3c831cba9a02" alt="코인끼리 홈 화면" width="250" />
